### PR TITLE
fix: correct typo 'lisenced' -> 'licensed' in copyright notice

### DIFF
--- a/src/KSeFCli/Program.cs
+++ b/src/KSeFCli/Program.cs
@@ -61,7 +61,7 @@ internal class Program
             {
                 HelpText helpText = HelpText.AutoBuild(result, h =>
                 {
-                    h.Copyright = "Copyright (C) 2026 Kamil Cukrowski. Source code lisenced under GPLv3.";
+                    h.Copyright = "Copyright (C) 2026 Kamil Cukrowski. Source code licensed under GPLv3.";
                     // new CopyrightInfo("Kamil Cukrowski", 2026);
                     h.AdditionalNewLineAfterOption = false;
                     return h;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling error in the copyright notice displayed in the help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->