### PR TITLE
Adds build script and fixes macOS quarantine issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             target: win-x64
             exe: ksefcli.exe
             artifact: ksefcli-win-x64.exe
-          - runner: macos-13
+          - runner: macos-15-intel
             target: osx-x64
             exe: ksefcli
             artifact: ksefcli-osx-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,29 +3,164 @@ name: Release
 
 on:
   push:
-    tags: ["*"]
+    tags: ["v*"]
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:
-  actions: read
-  attestations: read
-  checks: write
   contents: write
-  deployments: read
-  discussions: read
   id-token: write
-  issues: read
-  pages: read
   packages: write
-  pull-requests: write
-  repository-projects: read
-  security-events: read
-  statuses: write
 
 jobs:
-  build-and-release:
-    name: Build binaries and create release
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: linux-x64
+            exe: ksefcli
+            artifact: ksefcli-linux-x64
+          - runner: ubuntu-latest
+            target: linux-arm64
+            exe: ksefcli
+            artifact: ksefcli-linux-arm64
+          - runner: windows-latest
+            target: win-x64
+            exe: ksefcli.exe
+            artifact: ksefcli-win-x64.exe
+          - runner: macos-13
+            target: osx-x64
+            exe: ksefcli
+            artifact: ksefcli-osx-x64
+          - runner: macos-latest
+            target: osx-arm64
+            exe: ksefcli
+            artifact: ksefcli-osx-arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Publish
+        shell: bash
+        run: |
+          dotnet publish src/KSeFCli/KSeFCli.csproj \
+            -c Release \
+            -r ${{ matrix.target }} \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:EnableCompressionInSingleFile=true \
+            -p:InvariantGlobalization=true \
+            -p:SourceRevisionId=${{ steps.version.outputs.tag }}
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "src/KSeFCli/bin/Release/net10.0/${{ matrix.target }}/publish/${{ matrix.exe }}" \
+             "dist/${{ matrix.artifact }}"
+          ls -lh dist/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
+
+  release:
+    name: Publish release
     runs-on: ubuntu-latest
+    needs: build-binaries
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get release metadata
+        id: meta
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "name=${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "name=Latest (dev build)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Set executable bits
+        run: |
+          chmod +x dist/ksefcli-linux-x64 \
+                   dist/ksefcli-linux-arm64 \
+                   dist/ksefcli-osx-x64 \
+                   dist/ksefcli-osx-arm64
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.name }}
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          generate_release_notes: ${{ steps.meta.outputs.prerelease == 'false' }}
+          body: |
+            ## Binaries
+
+            | Platform | File |
+            |----------|------|
+            | Linux x64 | `ksefcli-linux-x64` |
+            | Linux arm64 | `ksefcli-linux-arm64` |
+            | Windows x64 | `ksefcli-win-x64.exe` |
+            | macOS x64 (Intel) | `ksefcli-osx-x64` |
+            | macOS arm64 (Apple Silicon) | `ksefcli-osx-arm64` |
+
+            After downloading, make the binary executable on Linux/macOS:
+            ```bash
+            chmod +x ksefcli-linux-x64   # or ksefcli-osx-arm64, etc.
+            ```
+          files: |
+            dist/ksefcli-linux-x64
+            dist/ksefcli-linux-arm64
+            dist/ksefcli-win-x64.exe
+            dist/ksefcli-osx-x64
+            dist/ksefcli-osx-arm64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Build & push Docker image
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build-binaries
 
     steps:
       - name: Checkout code
@@ -40,25 +175,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image (all platforms)
+      - name: Build Docker image
         run: |
           docker build \
             --build-arg VERSION=${{ steps.tag.outputs.tag }} \
             -t ksefcli:${{ steps.tag.outputs.tag }} .
 
-      - name: Extract binaries from Docker image
-        run: |
-          mkdir -p dist
-          docker create --name ksefcli-extract ksefcli:${{ steps.tag.outputs.tag }}
-          docker cp ksefcli-extract:/output/linux-x64/ksefcli   dist/ksefcli-linux-x64
-          docker cp ksefcli-extract:/output/win-x64/ksefcli.exe dist/ksefcli-win-x64.exe
-          docker cp ksefcli-extract:/output/osx-x64/ksefcli     dist/ksefcli-osx-x64
-          docker cp ksefcli-extract:/output/osx-arm64/ksefcli   dist/ksefcli-osx-arm64
-          docker rm ksefcli-extract
-          ls -lh dist/
-
       - name: Login to DockerHub
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -66,40 +190,14 @@ jobs:
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
-      - name: Push Docker image to DockerHub
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+      - name: Push Docker image
+        if: env.DOCKERHUB_USERNAME != ''
         run: |
-          docker tag ksefcli:${{ steps.tag.outputs.tag }} ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:${{ steps.tag.outputs.tag }}
-          docker tag ksefcli:${{ steps.tag.outputs.tag }} ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:latest
+          docker tag ksefcli:${{ steps.tag.outputs.tag }} \
+            ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:${{ steps.tag.outputs.tag }}
+          docker tag ksefcli:${{ steps.tag.outputs.tag }} \
+            ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:latest
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:${{ steps.tag.outputs.tag }}
           docker push ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:latest
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          generate_release_notes: true
-          files: |
-            dist/ksefcli-linux-x64
-            dist/ksefcli-win-x64.exe
-            dist/ksefcli-osx-x64
-            dist/ksefcli-osx-arm64
-          body: |
-            ## Binaries
-
-            | Platform | File |
-            |----------|------|
-            | Linux x64 | `ksefcli-linux-x64` |
-            | Windows x64 | `ksefcli-win-x64.exe` |
-            | macOS x64 (Intel) | `ksefcli-osx-x64` |
-            | macOS arm64 (Apple Silicon) | `ksefcli-osx-arm64` |
-
-            ## Docker
-
-            ```bash
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/ksefcli:${{ steps.tag.outputs.tag }}
-            ```
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Umieść `ksefcli-osx-arm64` (Apple Silicon) lub `ksefcli-osx-x64` (Intel) w wyb
 chmod +x ksefcli-osx-arm64
 ```
 
+Plik pobrany z internetu jest domyślnie objęty kwarantanną macOS (Gatekeeper), co blokuje ładowanie natywnych bibliotek i powoduje błąd przy generowaniu PDF. Usuń atrybut kwarantanny przed pierwszym uruchomieniem:
+
+```bash
+xattr -dr com.apple.quarantine ksefcli-osx-arm64
+```
+
 #### Linux
 
 Umieść `ksefcli-linux-x64` w wybranym miejscu i nadaj uprawnienia do wykonania:
@@ -257,6 +263,12 @@ Place `ksefcli-osx-arm64` (Apple Silicon) or `ksefcli-osx-x64` (Intel) anywhere 
 
 ```bash
 chmod +x ksefcli-osx-arm64
+```
+
+Files downloaded from the internet are quarantined by macOS Gatekeeper, which prevents native libraries from loading and causes a crash on PDF generation. Clear the quarantine attribute before first run:
+
+```bash
+xattr -dr com.apple.quarantine ksefcli-osx-arm64
 ```
 
 #### Linux

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# build.sh — build ksefcli self-contained binary for testing outside GitHub
+#
+# Usage:
+#   ./build.sh                  — build for current platform (auto-detected)
+#   ./build.sh linux-x64        — cross-compile for specific target
+#   ./build.sh all              — cross-compile all targets
+#   ./build.sh --help           — show this help
+#
+# Output: dist/ksefcli-<target>  (or dist/ksefcli-<target>.exe on Windows)
+# Requires: .NET SDK 10+
+
+set -euo pipefail
+
+TARGETS=(linux-x64 linux-arm64 win-x64 osx-x64 osx-arm64)
+PROJECT="src/KSeFCli/KSeFCli.csproj"
+
+usage() {
+    sed -n '2,12p' "$0" | sed 's/^# //' | sed 's/^#//'
+    echo ""
+    echo "Available targets: ${TARGETS[*]}"
+    exit 0
+}
+
+detect_platform() {
+    local os arch
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="osx" ;;
+        MINGW*|MSYS*|CYGWIN*) os="win" ;;
+        *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+    esac
+    case "$(uname -m)" in
+        x86_64|amd64) arch="x64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+    esac
+    echo "${os}-${arch}"
+}
+
+build_target() {
+    local target="$1"
+    local version
+    version="$(git describe --tags --always 2>/dev/null || echo "dev")"
+
+    echo "==> Building for ${target} (version: ${version})"
+
+    dotnet publish "${PROJECT}" \
+        -c Release \
+        -r "${target}" \
+        --self-contained true \
+        -p:PublishSingleFile=true \
+        -p:EnableCompressionInSingleFile=true \
+        -p:InvariantGlobalization=true \
+        -p:SourceRevisionId="${version}"
+
+    mkdir -p dist
+    local src_base="src/KSeFCli/bin/Release/net10.0/${target}/publish"
+    if [[ "${target}" == win-* ]]; then
+        cp "${src_base}/ksefcli.exe" "dist/ksefcli-${target}.exe"
+        echo "    dist/ksefcli-${target}.exe"
+        ls -lh "dist/ksefcli-${target}.exe"
+    else
+        cp "${src_base}/ksefcli" "dist/ksefcli-${target}"
+        chmod +x "dist/ksefcli-${target}"
+        echo "    dist/ksefcli-${target}"
+        ls -lh "dist/ksefcli-${target}"
+    fi
+}
+
+# --- argument parsing ---
+
+case "${1:-}" in
+    --help|-h) usage ;;
+    all)
+        for t in "${TARGETS[@]}"; do build_target "$t"; done
+        echo ""
+        echo "Done. Binaries in dist/:"
+        ls -lh dist/
+        ;;
+    "")
+        build_target "$(detect_platform)"
+        ;;
+    *)
+        # validate supplied target
+        valid=false
+        for t in "${TARGETS[@]}"; do [[ "$1" == "$t" ]] && valid=true && break; done
+        if ! $valid; then
+            echo "Unknown target: $1" >&2
+            echo "Valid targets: ${TARGETS[*]}" >&2
+            exit 1
+        fi
+        build_target "$1"
+        ;;
+esac

--- a/src/KSeFCli/KSeFCli.csproj
+++ b/src/KSeFCli/KSeFCli.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="QuestPDF" Version="2024.12.0" />
+    <PackageReference Include="QuestPDF" Version="2025.12.4" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client/KSeF.Client.csproj" NoWarn="CS9107;CA1305;CA1816;CA1852;CS8002;CA1305;CA1852;CA1816;CA1852;CA1305;CS9107;CA1805" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client.Core/KSeF.Client.Core.csproj" NoWarn="CA1805" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client.ClientFactory/KSeF.Client.ClientFactory.csproj" NoWarn="CS9107;CA1305;CA1816;CA1852;CS8002;CA1305;CA1852;CA1816;CA1852;CA1305;CS9107;CA1805" />

--- a/src/KSeFCli/KSeFCli.csproj
+++ b/src/KSeFCli/KSeFCli.csproj
@@ -32,6 +32,12 @@
     </ItemGroup>
   </Target>
 
+  <!-- Extract native libs (SkiaSharp/QuestPDF) from single-file bundle at startup.
+       Required on Windows; harmless on Linux/macOS. Only active during publish. -->
+  <PropertyGroup Condition="'$(PublishSingleFile)' == 'true'">
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />


### PR DESCRIPTION
Introduces local build capabilities and resolves macOS Gatekeeper restrictions:

- Adds comprehensive build script supporting cross-platform compilation for all target architectures
- Configures native library extraction for single-file bundles to prevent runtime crashes
- Documents macOS quarantine removal process to fix PDF generation failures

Enhances development workflow by enabling local testing builds outside of GitHub Actions while addressing platform-specific deployment issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prebuilt self-contained binaries produced for Linux, macOS (x64/arm64) and Windows, published per-target.

* **Documentation**
  * Added macOS Gatekeeper guidance to clear quarantine for downloaded binaries.

* **Chores**
  * Reworked release automation for parallel multi-platform builds, per-target artifact handling and release publishing.
  * Added optional Docker image publishing on tagged releases.
* **Dependencies**
  * Updated QuestPDF to a newer release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->