### PR TITLE
chore: remove unused ksef-docs and ksef-pdf-generator submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,3 @@
-[submodule "thirdparty/ksef-docs"]
-	path = thirdparty/ksef-docs
-	url = https://github.com/CIRFMF/ksef-docs
 [submodule "thirdparty/ksef-client-csharp"]
 	path = thirdparty/ksef-client-csharp
 	url = https://github.com/CIRFMF/ksef-client-csharp
-
-[submodule "ksef-pdf-generator"]
-	path = thirdparty/ksef-pdf-generator
-	url = https://github.com/CIRFMF/ksef-pdf-generator


### PR DESCRIPTION
PDF generation is now handled natively via QuestPDF. ksef-docs is reference documentation not used in the build. Both were cloned unnecessarily on every CI checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed two submodule dependencies from the project, including documentation and PDF generation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->