### PR TITLE
feat: adds SQLite invoice cache with background refresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -e && \
     dotnet publish src/KSeFCli/KSeFCli.csproj $ARGS -r osx-x64 && \
     dotnet publish src/KSeFCli/KSeFCli.csproj $ARGS -r osx-arm64
 
-# --- Final stage: ksefcli binaries only (PDF generation requires Node.js+npx at runtime) ---
+# --- Final stage: ksefcli binaries (PDF renderer is built-in, no external tools needed) ---
 FROM debian:bookworm-slim
 
 ARG APP_VERSION

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Zakładka **Ogólne**:
 - Wybór aktywnego profilu (zapamiętywany między sesjami; zmiana profilu działa natychmiast bez restartu, lista faktur ładowana z pamięci podręcznej)
 - **Auto-odświeżanie** — cykliczne wyszukiwanie co N minut (0 = wyłączone):
   - Aktywny profil: automatyczne odświeżanie w tle obsługiwane przez przeglądarkę
-  - Pozostałe profile oznaczone jako *Uwzględnij w auto-odświeżaniu* (patrz edytor konfiguracji): przeszukiwane w tle przez serwer C#, wyniki zapisywane do bazy danych; powiadomienie (systemowe lub badge🔔 w liście profili) gdy pojawią się nowe faktury
+  - Pozostałe profile oznaczone jako *Uwzględnij w auto-odświeżaniu* (patrz edytor konfiguracji): przeszukiwane w tle przez serwer C#, wyniki zapisywane do bazy danych; powiadomienie (systemowe lub badge🔔 w liście profili), gdy pojawią się nowe faktury
 
 Zakładka **Eksport**:
 - Szczegółowe opcje eksportu plików

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Preferencje zapisywane są w: `~/.cache/ksefcli/gui-prefs.json`
 
 Wyniki wyszukiwania są zapisywane lokalnie w bazie SQLite:
 
-```
+```text
 ~/.cache/ksefcli/db/invoice-cache.db
 ```
 
@@ -563,7 +563,7 @@ Preferences stored at: `~/.cache/ksefcli/gui-prefs.json`
 
 Search results are persisted locally in a SQLite database:
 
-```
+```text
 ~/.cache/ksefcli/db/invoice-cache.db
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - back
     volumes:
       - ksefcli-config:/root/.config/ksefcli
-      - ./output:/data
+      - ksefcli-output:/data
       - ksefcli-cache:/root/.cache/ksefcli
     environment:
       TZ: ${TZ:-UTC}
@@ -128,6 +128,8 @@ volumes:
   ksefcli-config:
     driver: local
   ksefcli-cache:
+    driver: local
+  ksefcli-output:
     driver: local
   traefik-acme:
     driver: local

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -815,7 +815,14 @@ public class GuiCommand : IWithConfigCommand
         IKSeFClient client = scope.ServiceProvider.GetRequiredService<IKSeFClient>();
         List<InvoiceSummary> invoices = await FetchAllPagesAsync(client, filters, accessToken, ct).ConfigureAwait(false);
 
-        _invoiceCache.SaveInvoicesOnly(profileKey, invoices);
+        if (prev == null)
+        {
+            _invoiceCache.Save(profileKey, sp, invoices);
+        }
+        else
+        {
+            _invoiceCache.SaveInvoicesOnly(profileKey, invoices);
+        }
 
         int newCount = invoices.Count(i => !prevKeys.Contains(i.KsefNumber));
         Log.LogInformation($"[bg-refresh] Profile '{name}': {invoices.Count} invoices, {newCount} new");

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+
+using KSeF.Client.Core.Models.Invoices;
+
+using Microsoft.Data.Sqlite;
+
+namespace KSeFCli;
+
+/// <summary>
+/// Persists the last invoice search result per profile in a local SQLite database.
+/// KSeF invoices are immutable, so cached data is always valid — the only reason to
+/// re-fetch is to discover newly arrived invoices.
+/// DB location: ~/.cache/ksefcli/db/invoice-cache.db
+/// </summary>
+internal sealed class InvoiceCache
+{
+    private static readonly string DefaultPath =
+        Path.Combine(IGlobalCommand.CacheDir, "db", "invoice-cache.db");
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private readonly string _dbPath;
+
+    public InvoiceCache(string? dbPath = null)
+    {
+        _dbPath = dbPath ?? DefaultPath;
+        bool isNew = !File.Exists(_dbPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);
+        Log.LogInformation($"Invoice cache DB: {_dbPath} ({(isNew ? "new" : $"{new FileInfo(_dbPath).Length / 1024.0:F1} KB")})");
+        EnsureSchema();
+    }
+
+    /// <summary>Creates the table if it does not already exist, and logs row counts per profile.</summary>
+    private void EnsureSchema()
+    {
+        using SqliteConnection conn = Open();
+        using SqliteCommand createCmd = conn.CreateCommand();
+        createCmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS invoice_cache (
+                profile_key   TEXT PRIMARY KEY,
+                params_json   TEXT NOT NULL,
+                invoices_json TEXT NOT NULL,
+                fetched_at    TEXT NOT NULL
+            )
+            """;
+        createCmd.ExecuteNonQuery();
+
+        // Log per-profile row summary for diagnostics
+        using SqliteCommand statsCmd = conn.CreateCommand();
+        statsCmd.CommandText = "SELECT profile_key, fetched_at, length(invoices_json) FROM invoice_cache ORDER BY fetched_at DESC";
+        using SqliteDataReader reader = statsCmd.ExecuteReader();
+        int rows = 0;
+        while (reader.Read())
+        {
+            rows++;
+            string key = reader.GetString(0);
+            string fetchedAt = reader.GetString(1);
+            long bytes = reader.GetInt64(2);
+            Log.LogDebug($"  cache row [{rows}]: profile_key={key[..Math.Min(24, key.Length)]}… fetched={fetchedAt} size={bytes / 1024.0:F1} KB");
+        }
+
+        if (rows == 0)
+        {
+            Log.LogInformation("Invoice cache: empty (no entries yet)");
+        }
+        else
+        {
+            Log.LogInformation($"Invoice cache: {rows} profile(s) stored");
+        }
+    }
+
+    /// <summary>
+    /// Loads the cached invoices and search params for the given profile key.
+    /// Returns (null, null, null) if no cache entry exists or the stored data is corrupt.
+    /// </summary>
+    public (List<InvoiceSummary>? Invoices, SearchParams? Params, DateTime? FetchedAt) Load(string profileKey)
+    {
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT invoices_json, params_json, fetched_at FROM invoice_cache WHERE profile_key = @key";
+        cmd.Parameters.AddWithValue("@key", profileKey);
+        using SqliteDataReader reader = cmd.ExecuteReader();
+        if (!reader.Read())
+        {
+            Log.LogInformation($"[cache] MISS — no entry for profile key {profileKey[..Math.Min(24, profileKey.Length)]}… → will use KSeF API");
+            return (null, null, null);
+        }
+
+        string invoicesJson = reader.GetString(0);
+        string paramsJson = reader.GetString(1);
+        string fetchedAtStr = reader.GetString(2);
+
+        try
+        {
+            List<InvoiceSummary>? invoices = JsonSerializer.Deserialize<List<InvoiceSummary>>(invoicesJson, _jsonOptions);
+            SearchParams? searchParams = JsonSerializer.Deserialize<SearchParams>(paramsJson, _jsonOptions);
+            DateTime fetchedAt = DateTime.Parse(fetchedAtStr, null, System.Globalization.DateTimeStyles.RoundtripKind);
+            Log.LogInformation($"[cache] HIT  — {invoices?.Count ?? 0} invoices from DB (fetched {fetchedAt:u}, {invoicesJson.Length / 1024.0:F1} KB)");
+            return (invoices, searchParams, fetchedAt);
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[cache] CORRUPT — deserialization failed for profile '{profileKey}': {ex.Message}. Ignoring stale entry → will use KSeF API");
+            return (null, null, null);
+        }
+    }
+
+    /// <summary>
+    /// Persists the invoice list AND search params. Call on manual (user-triggered) searches only.
+    /// Cyclic (auto-refresh) searches should call <see cref="SaveInvoicesOnly"/> to avoid
+    /// overwriting the user's last explicit search params with whatever the auto-refresh used.
+    /// </summary>
+    public void Save(string profileKey, SearchParams searchParams, List<InvoiceSummary> invoices)
+    {
+        string invoicesJson = JsonSerializer.Serialize(invoices);
+        string paramsJson = JsonSerializer.Serialize(searchParams);
+        string fetchedAt = DateTime.UtcNow.ToString("o");
+
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO invoice_cache (profile_key, params_json, invoices_json, fetched_at)
+            VALUES (@key, @params, @invoices, @at)
+            ON CONFLICT(profile_key) DO UPDATE SET
+                params_json   = excluded.params_json,
+                invoices_json = excluded.invoices_json,
+                fetched_at    = excluded.fetched_at
+            """;
+        cmd.Parameters.AddWithValue("@key", profileKey);
+        cmd.Parameters.AddWithValue("@params", paramsJson);
+        cmd.Parameters.AddWithValue("@invoices", invoicesJson);
+        cmd.Parameters.AddWithValue("@at", fetchedAt);
+        cmd.ExecuteNonQuery();
+        Log.LogInformation($"[cache] WRITE — {invoices.Count} invoices + params saved to DB ({invoicesJson.Length / 1024.0:F1} KB, profile key {profileKey[..Math.Min(24, profileKey.Length)]}…)");
+    }
+
+    /// <summary>
+    /// Updates only the invoice list for the given profile key, leaving params_json untouched.
+    /// Call on cyclic (auto-refresh) searches so the user's explicit search params are preserved.
+    /// </summary>
+    public void SaveInvoicesOnly(string profileKey, List<InvoiceSummary> invoices)
+    {
+        string invoicesJson = JsonSerializer.Serialize(invoices);
+        string fetchedAt = DateTime.UtcNow.ToString("o");
+
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        // UPDATE only — if no row exists yet (user never searched manually), skip silently.
+        cmd.CommandText = """
+            UPDATE invoice_cache
+            SET invoices_json = @invoices,
+                fetched_at    = @at
+            WHERE profile_key = @key
+            """;
+        cmd.Parameters.AddWithValue("@key", profileKey);
+        cmd.Parameters.AddWithValue("@invoices", invoicesJson);
+        cmd.Parameters.AddWithValue("@at", fetchedAt);
+        int affected = cmd.ExecuteNonQuery();
+        if (affected > 0)
+        {
+            Log.LogInformation($"[cache] WRITE (invoices only) — {invoices.Count} invoices updated in DB ({invoicesJson.Length / 1024.0:F1} KB, profile key {profileKey[..Math.Min(24, profileKey.Length)]}…)");
+        }
+    }
+
+    private SqliteConnection Open()
+    {
+        SqliteConnection conn = new SqliteConnection($"Data Source={_dbPath}");
+        conn.Open();
+        return conn;
+    }
+}

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -28,7 +28,11 @@ internal sealed class InvoiceCache
     {
         _dbPath = dbPath ?? DefaultPath;
         bool isNew = !File.Exists(_dbPath);
-        Directory.CreateDirectory(Path.GetDirectoryName(_dbPath)!);
+        string? dir = Path.GetDirectoryName(_dbPath);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
         Log.LogInformation($"Invoice cache DB: {_dbPath} ({(isNew ? "new" : $"{new FileInfo(_dbPath).Length / 1024.0:F1} KB")})");
         EnsureSchema();
     }

--- a/src/KSeFCli/KSeFCli.csproj
+++ b/src/KSeFCli/KSeFCli.csproj
@@ -32,9 +32,9 @@
     </ItemGroup>
   </Target>
 
-  <!-- Extract native libs (SkiaSharp/QuestPDF) from single-file bundle at startup.
+  <!-- Extract native libs (SkiaSharp/QuestPDF/SQLite) from single-file bundle at startup.
        Required on Windows; harmless on Linux/macOS. Only active during publish. -->
-  <PropertyGroup Condition="'$(PublishSingleFile)' == 'true'">
+  <PropertyGroup Condition="'$(PublishSingleFile)' == 'true' Or '$(SelfContained)' == 'true'">
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
@@ -54,6 +54,8 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
+    <!-- Explicit native SQLite bundle required for correct self-contained single-file publish -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client/KSeF.Client.csproj" NoWarn="CS9107;CA1305;CA1816;CA1852;CS8002;CA1305;CA1852;CA1816;CA1852;CA1305;CS9107;CA1805" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client.Core/KSeF.Client.Core.csproj" NoWarn="CA1805" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client.ClientFactory/KSeF.Client.ClientFactory.csproj" NoWarn="CS9107;CA1305;CA1816;CA1852;CS8002;CA1305;CA1852;CA1816;CA1852;CA1305;CS9107;CA1805" />

--- a/src/KSeFCli/KSeFCli.csproj
+++ b/src/KSeFCli/KSeFCli.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.3" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client/KSeF.Client.csproj" NoWarn="CS9107;CA1305;CA1816;CA1852;CS8002;CA1305;CA1852;CA1816;CA1852;CA1305;CS9107;CA1805" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client.Core/KSeF.Client.Core.csproj" NoWarn="CA1805" />
     <ProjectReference Include="../../thirdparty/ksef-client-csharp/KSeF.Client.ClientFactory/KSeF.Client.ClientFactory.csproj" NoWarn="CS9107;CA1305;CA1816;CA1852;CS8002;CA1305;CA1852;CA1816;CA1852;CA1305;CS9107;CA1805" />

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1328,7 +1328,7 @@ function renderProfileCard(p, i) {
     '<div class="cfg-field"><label>Haslo z pliku (opcjonalnie)</label>' +
     '<input type="text" id="cfgCertPassFile' + i + '" value="' + esc(p.certPasswordFile||'') + '" placeholder="~/password.txt"></div>' +
     '</div>' +
-    '<div class="cfg-field" style="padding-top:.4rem;border-top:1px solid var(--border)">' +
+    '<div class="cfg-field" style="padding-top:.4rem;border-top:1px solid var(--border,#ccc)">' +
     '<label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.85rem">' +
     '<input type="checkbox" id="cfgAutoRefresh' + i + '"' + (p.includeInAutoRefresh ? ' checked' : '') + '>' +
     ' Uwzględnij w auto-odświeżaniu (tło)</label></div>' +

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1683,11 +1683,13 @@ function updateProfileSelectBadges() {
 
 // Extensible notification hook — swap for email/Slack in future
 function notifyNewInvoices(profileName, count) {
-  if (Notification.permission === 'granted') {
+  if (typeof Notification === 'undefined') return;
+  if (Notification.permission !== 'granted') return;
+  try {
     new Notification('KSeF: nowe faktury (' + profileName + ')', {
       body: count + ' nowych faktur dla profilu ' + profileName
     });
-  }
+  } catch (e) { /* notification not supported in this context */ }
 }
 
 async function doAuth() {

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1107,8 +1107,7 @@ async function loadPrefs() {
     }
   } catch {}
 }
-loadPrefs();
-loadCachedInvoices();
+loadPrefs().then(() => loadCachedInvoices());
 
 function applySetupMode(required) {
   const banner = $('setupBanner');


### PR DESCRIPTION
Implements persistent storage for search results to improve performance and user experience

- Adds SQLite database for caching invoices per profile
- Enables automatic token refresh on startup when expired
- Implements background monitoring for inactive profiles
- Adds display row limits with expand functionality
- Switches to named Docker volumes for better persistence
- Updates built-in PDF renderer without external dependencies
- Improves profile switching with instant cached data loading

Cache survives restarts and eliminates redundant API calls for previously searched data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile invoice caching with fast preload on page load and persisted local cache
  * Per-profile auto-refresh (background refresh for inactive profiles) and profile-specific GUI preferences
  * Display row limit with "Show All" control, notification badges for new invoices, and automatic access-token refresh when possible

* **Documentation**
  * Docker now uses a persistent named output volume
  * README clarifications, PDF export notes updated to state built-in renderer and other onboarding/config guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->