### PR TITLE
fix: prevents path traversal vulnerability

### DIFF
--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -271,11 +271,13 @@ internal sealed class WebProgressServer : IDisposable
             await HandleAction(ctx, ct, () =>
             {
                 string rawPath = ctx.Request.QueryString["path"] ?? DefaultBrowseDir;
-                string fsRoot = Path.GetPathRoot(Path.GetFullPath(rawPath)) ?? "/";
+                // Derive the allowed filesystem root from a server-side value, not from the user-provided path,
+                // so the boundary cannot be manipulated by the caller.
+                string fsRoot = Path.GetPathRoot(Path.GetFullPath(DefaultBrowseDir)) ?? "/";
                 string dirPath = Path.GetFullPath(rawPath);
                 if (!dirPath.StartsWith(fsRoot, StringComparison.Ordinal))
                 {
-                    throw new UnauthorizedAccessException("Path is outside the filesystem root.");
+                    throw new UnauthorizedAccessException("Path is outside the allowed filesystem.");
                 }
                 if (!Directory.Exists(dirPath))
                 {


### PR DESCRIPTION
Changes filesystem root derivation to use server-side default
instead of user-provided path to prevent boundary manipulation

Updates error message for clearer security context
Adds explanatory comment documenting security rationale


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security protections in the browse feature to prevent filesystem boundary manipulation attacks.
  * Improved error message clarity when attempting to access restricted filesystem paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->