### PR TITLE
feat: adds webhook notifications for new invoices

### DIFF
--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -590,7 +590,7 @@ public class GuiCommand : IWithConfigCommand
             });
         };
 
-        server.OnTestNotification = async (body) =>
+        server.OnTestNotification = async (body, ct) =>
         {
             string profileName;
             try
@@ -598,7 +598,8 @@ public class GuiCommand : IWithConfigCommand
                 using JsonDocument doc = JsonDocument.Parse(body);
                 profileName = doc.RootElement.TryGetProperty("profileName", out JsonElement pn) ? pn.GetString() ?? ActiveProfile : ActiveProfile;
             }
-            catch { profileName = ActiveProfile; }
+            catch (JsonException) { profileName = ActiveProfile; }
+            catch (ArgumentException) { profileName = ActiveProfile; }
 
             GuiPrefs prefs = LoadPrefs();
             ProfilePrefs? pp = prefs.ProfilePrefs?.GetValueOrDefault(profileName);
@@ -608,12 +609,12 @@ public class GuiCommand : IWithConfigCommand
             List<Task> tasks = [];
             if (!string.IsNullOrEmpty(slackUrl))
             {
-                tasks.Add(SendSlackNotificationAsync(slackUrl, profileName, 3, CancellationToken.None));
+                tasks.Add(SendSlackNotificationAsync(slackUrl, profileName, 3, ct));
                 sent++;
             }
             if (!string.IsNullOrEmpty(teamsUrl))
             {
-                tasks.Add(SendTeamsNotificationAsync(teamsUrl, profileName, 3, CancellationToken.None));
+                tasks.Add(SendTeamsNotificationAsync(teamsUrl, profileName, 3, ct));
                 sent++;
             }
             if (tasks.Count > 0)
@@ -945,7 +946,8 @@ public class GuiCommand : IWithConfigCommand
                 Log.LogWarning($"[slack-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
             }
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (HttpRequestException ex)
         {
             Log.LogWarning($"[slack-notify] Failed for profile '{profileName}': {ex.Message}");
         }
@@ -953,14 +955,14 @@ public class GuiCommand : IWithConfigCommand
 
     private static async Task SendTeamsNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct)
     {
-        var payload = new
+        Dictionary<string, object> payload = new()
         {
-            type = "MessageCard",
-            context = "http://schema.org/extensions",
-            summary = $"KSeF: {newCount} nowych faktur",
-            themeColor = "0078D4",
-            title = "KSeF: Nowe faktury",
-            text = $"Profil **{profileName}**: {newCount} nowych faktur",
+            ["@type"] = "MessageCard",
+            ["@context"] = "https://schema.org/extensions",
+            ["summary"] = $"KSeF: {newCount} nowych faktur",
+            ["themeColor"] = "0078D4",
+            ["title"] = "KSeF: Nowe faktury",
+            ["text"] = $"Profil **{profileName}**: {newCount} nowych faktur",
         };
         string json = JsonSerializer.Serialize(payload);
         using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -972,7 +974,8 @@ public class GuiCommand : IWithConfigCommand
                 Log.LogWarning($"[teams-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
             }
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (HttpRequestException ex)
         {
             Log.LogWarning($"[teams-notify] Failed for profile '{profileName}': {ex.Message}");
         }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -45,7 +45,7 @@ public class GuiCommand : IWithConfigCommand
     private bool _setupRequired = false;
 
     private static readonly string PrefsPath = Path.Combine(CacheDir, "gui-prefs.json");
-    private static readonly HttpClient _httpClient = new();
+    private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(10) };
 
     private const int DefaultLanPort = 18150;
 
@@ -623,6 +623,10 @@ public class GuiCommand : IWithConfigCommand
                 await Task.WhenAll(tasks.Select(t => t.Task)).ConfigureAwait(false);
                 return $"Wysłano test do {tasks.Count} kanał(ów).";
             }
+            catch (Exception ex) when (ex is OperationCanceledException || ex is TaskCanceledException)
+            {
+                throw;
+            }
             catch
             {
                 List<string> failed = tasks.Where(t => t.Task.IsFaulted || t.Task.IsCanceled).Select(t => t.Name).ToList();
@@ -935,13 +939,18 @@ public class GuiCommand : IWithConfigCommand
                 _invoiceCache.MarkAsNotified(profileKey, toNotify);
                 string? slackUrl = profilePrefs?.SlackWebhookUrl;
                 string? teamsUrl = profilePrefs?.TeamsWebhookUrl;
+                List<Task> webhookTasks = [];
                 if (!string.IsNullOrEmpty(slackUrl))
                 {
-                    await SendSlackNotificationAsync(slackUrl, name, toNotify.Count, ct).ConfigureAwait(false);
+                    webhookTasks.Add(SendSlackNotificationAsync(slackUrl, name, toNotify.Count, ct));
                 }
                 if (!string.IsNullOrEmpty(teamsUrl))
                 {
-                    await SendTeamsNotificationAsync(teamsUrl, name, toNotify.Count, ct).ConfigureAwait(false);
+                    webhookTasks.Add(SendTeamsNotificationAsync(teamsUrl, name, toNotify.Count, ct));
+                }
+                if (webhookTasks.Count > 0)
+                {
+                    await Task.WhenAll(webhookTasks).ConfigureAwait(false);
                 }
             }
         }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
 
@@ -44,11 +45,15 @@ public class GuiCommand : IWithConfigCommand
     private bool _setupRequired = false;
 
     private static readonly string PrefsPath = Path.Combine(CacheDir, "gui-prefs.json");
+    private static readonly HttpClient _httpClient = new();
 
     private const int DefaultLanPort = 18150;
 
     /// <summary>Persistent GUI-only preferences per profile name (not stored in YAML).</summary>
-    private record ProfilePrefs(bool? IncludeInAutoRefresh = null);
+    private record ProfilePrefs(
+        bool? IncludeInAutoRefresh = null,
+        string? SlackWebhookUrl = null,
+        string? TeamsWebhookUrl = null);
 
     private record GuiPrefs(
         string? OutputDir = null,
@@ -80,7 +85,9 @@ public class GuiCommand : IWithConfigCommand
         string? CertPassword,
         string? CertPasswordEnv,
         string? CertPasswordFile,
-        bool IncludeInAutoRefresh = true);
+        bool IncludeInAutoRefresh = true,
+        string? SlackWebhookUrl = null,
+        string? TeamsWebhookUrl = null);
 
     private record ConfigEditorData(
         string ActiveProfile,
@@ -458,7 +465,9 @@ public class GuiCommand : IWithConfigCommand
                     CertPassword: kvp.Value.Certificate?.Password,
                     CertPasswordEnv: kvp.Value.Certificate?.Password_Env,
                     CertPasswordFile: kvp.Value.Certificate?.Password_File,
-                    IncludeInAutoRefresh: !ppMap.TryGetValue(kvp.Key, out ProfilePrefs? pp) || pp.IncludeInAutoRefresh != false))
+                    IncludeInAutoRefresh: !ppMap.TryGetValue(kvp.Key, out ProfilePrefs? pp) || pp.IncludeInAutoRefresh != false,
+                    SlackWebhookUrl: pp?.SlackWebhookUrl,
+                    TeamsWebhookUrl: pp?.TeamsWebhookUrl))
                 .ToArray();
             return Task.FromResult<object>(new ConfigEditorData(
                 ActiveProfile: rawConfig.ActiveProfile,
@@ -540,7 +549,10 @@ public class GuiCommand : IWithConfigCommand
                     ?? new Dictionary<string, ProfilePrefs>();
                 foreach (ProfileEditorData p in data.Profiles)
                 {
-                    updatedPpMap[p.Name] = new ProfilePrefs(IncludeInAutoRefresh: p.IncludeInAutoRefresh);
+                    updatedPpMap[p.Name] = new ProfilePrefs(
+                        IncludeInAutoRefresh: p.IncludeInAutoRefresh,
+                        SlackWebhookUrl: string.IsNullOrWhiteSpace(p.SlackWebhookUrl) ? null : p.SlackWebhookUrl,
+                        TeamsWebhookUrl: string.IsNullOrWhiteSpace(p.TeamsWebhookUrl) ? null : p.TeamsWebhookUrl);
                 }
                 // Remove entries for profiles that no longer exist
                 foreach (string stale in updatedPpMap.Keys.Except(data.Profiles.Select(p => p.Name)).ToList())
@@ -576,6 +588,39 @@ public class GuiCommand : IWithConfigCommand
                 author = "Marcin Bojko",
                 github = "https://github.com/marcinbojko/ksef-gui",
             });
+        };
+
+        server.OnTestNotification = async (body) =>
+        {
+            string profileName;
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(body);
+                profileName = doc.RootElement.TryGetProperty("profileName", out JsonElement pn) ? pn.GetString() ?? ActiveProfile : ActiveProfile;
+            }
+            catch { profileName = ActiveProfile; }
+
+            GuiPrefs prefs = LoadPrefs();
+            ProfilePrefs? pp = prefs.ProfilePrefs?.GetValueOrDefault(profileName);
+            string? slackUrl = pp?.SlackWebhookUrl;
+            string? teamsUrl = pp?.TeamsWebhookUrl;
+            int sent = 0;
+            List<Task> tasks = [];
+            if (!string.IsNullOrEmpty(slackUrl))
+            {
+                tasks.Add(SendSlackNotificationAsync(slackUrl, profileName, 3, CancellationToken.None));
+                sent++;
+            }
+            if (!string.IsNullOrEmpty(teamsUrl))
+            {
+                tasks.Add(SendTeamsNotificationAsync(teamsUrl, profileName, 3, CancellationToken.None));
+                sent++;
+            }
+            if (tasks.Count > 0)
+            {
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            return sent == 0 ? "Brak skonfigurowanych webhooków dla tego profilu." : $"Wysłano test do {sent} kanał(ów).";
         };
 
         server.Start(cancellationToken);
@@ -799,14 +844,15 @@ public class GuiCommand : IWithConfigCommand
                     continue; // JS silentRefresh handles the active profile
                 }
 
-                if (ppMap.TryGetValue(name, out ProfilePrefs? pp) && pp.IncludeInAutoRefresh == false)
+                ProfilePrefs? profilePrefs = ppMap.TryGetValue(name, out ProfilePrefs? pp) ? pp : null;
+                if (profilePrefs?.IncludeInAutoRefresh == false)
                 {
                     continue;
                 }
 
                 try
                 {
-                    await RefreshProfileInBackgroundAsync(name, profile, ct).ConfigureAwait(false);
+                    await RefreshProfileInBackgroundAsync(name, profile, profilePrefs, ct).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -816,7 +862,7 @@ public class GuiCommand : IWithConfigCommand
         }
     }
 
-    private async Task RefreshProfileInBackgroundAsync(string name, ProfileConfig profile, CancellationToken ct)
+    private async Task RefreshProfileInBackgroundAsync(string name, ProfileConfig profile, ProfilePrefs? profilePrefs, CancellationToken ct)
     {
         Log.LogInformation($"[bg-refresh] Profile '{name}' (NIP {profile.Nip}, env {profile.Environment}) starting");
         using IServiceScope scope = GetScope(profile);
@@ -836,6 +882,9 @@ public class GuiCommand : IWithConfigCommand
         if (prev == null)
         {
             _invoiceCache.Save(profileKey, sp, invoices);
+            // First ever run for this profile: seed the notification baseline so we don't
+            // blast the user with the entire invoice history on the first refresh cycle.
+            _invoiceCache.MarkAsNotified(profileKey, invoices.Select(i => i.KsefNumber));
         }
         else
         {
@@ -853,6 +902,79 @@ public class GuiCommand : IWithConfigCommand
                 count = invoices.Count,
                 newCount,
             }).ConfigureAwait(false);
+        }
+
+        // Webhooks fire only for invoices that are both new (not in prev cache) and not yet
+        // notified (not in notification_sent table). This prevents duplicate webhook calls
+        // across refresh cycles and across app restarts.
+        if (newCount > 0 && prev != null)
+        {
+            HashSet<string> alreadyNotified = _invoiceCache.LoadNotifiedKsefNumbers(profileKey);
+            List<string> toNotify = invoices
+                .Where(i => !prevKeys.Contains(i.KsefNumber) && !alreadyNotified.Contains(i.KsefNumber))
+                .Select(i => i.KsefNumber)
+                .ToList();
+
+            if (toNotify.Count > 0)
+            {
+                _invoiceCache.MarkAsNotified(profileKey, toNotify);
+                string? slackUrl = profilePrefs?.SlackWebhookUrl;
+                string? teamsUrl = profilePrefs?.TeamsWebhookUrl;
+                if (!string.IsNullOrEmpty(slackUrl))
+                {
+                    await SendSlackNotificationAsync(slackUrl, name, toNotify.Count, ct).ConfigureAwait(false);
+                }
+                if (!string.IsNullOrEmpty(teamsUrl))
+                {
+                    await SendTeamsNotificationAsync(teamsUrl, name, toNotify.Count, ct).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private static async Task SendSlackNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct)
+    {
+        string text = $"KSeF: {newCount} nowych faktur dla profilu {profileName}";
+        string json = JsonSerializer.Serialize(new { text });
+        using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
+        try
+        {
+            using HttpResponseMessage resp = await _httpClient.PostAsync(webhookUrl, content, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                Log.LogWarning($"[slack-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[slack-notify] Failed for profile '{profileName}': {ex.Message}");
+        }
+    }
+
+    private static async Task SendTeamsNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct)
+    {
+        var payload = new
+        {
+            type = "MessageCard",
+            context = "http://schema.org/extensions",
+            summary = $"KSeF: {newCount} nowych faktur",
+            themeColor = "0078D4",
+            title = "KSeF: Nowe faktury",
+            text = $"Profil **{profileName}**: {newCount} nowych faktur",
+        };
+        string json = JsonSerializer.Serialize(payload);
+        using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
+        try
+        {
+            using HttpResponseMessage resp = await _httpClient.PostAsync(webhookUrl, content, ct).ConfigureAwait(false);
+            if (!resp.IsSuccessStatusCode)
+            {
+                Log.LogWarning($"[teams-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[teams-notify] Failed for profile '{profileName}': {ex.Message}");
         }
     }
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -605,23 +605,33 @@ public class GuiCommand : IWithConfigCommand
             ProfilePrefs? pp = prefs.ProfilePrefs?.GetValueOrDefault(profileName);
             string? slackUrl = pp?.SlackWebhookUrl;
             string? teamsUrl = pp?.TeamsWebhookUrl;
-            int sent = 0;
-            List<Task> tasks = [];
+            List<(string Name, Task Task)> tasks = [];
             if (!string.IsNullOrEmpty(slackUrl))
             {
-                tasks.Add(SendSlackNotificationAsync(slackUrl, profileName, 3, ct));
-                sent++;
+                tasks.Add(("Slack", SendSlackNotificationAsync(slackUrl, profileName, 3, ct)));
             }
             if (!string.IsNullOrEmpty(teamsUrl))
             {
-                tasks.Add(SendTeamsNotificationAsync(teamsUrl, profileName, 3, ct));
-                sent++;
+                tasks.Add(("Teams", SendTeamsNotificationAsync(teamsUrl, profileName, 3, ct)));
             }
-            if (tasks.Count > 0)
+            if (tasks.Count == 0)
             {
-                await Task.WhenAll(tasks).ConfigureAwait(false);
+                return "Brak skonfigurowanych webhooków dla tego profilu.";
             }
-            return sent == 0 ? "Brak skonfigurowanych webhooków dla tego profilu." : $"Wysłano test do {sent} kanał(ów).";
+            try
+            {
+                await Task.WhenAll(tasks.Select(t => t.Task)).ConfigureAwait(false);
+                return $"Wysłano test do {tasks.Count} kanał(ów).";
+            }
+            catch
+            {
+                List<string> failed = tasks.Where(t => t.Task.IsFaulted || t.Task.IsCanceled).Select(t => t.Name).ToList();
+                int ok = tasks.Count - failed.Count;
+                string failMsg = string.Join(", ", failed);
+                return ok > 0
+                    ? $"Wysłano do {ok} kanał(ów), błąd w: {failMsg}."
+                    : $"Błąd wysyłki do: {failMsg}.";
+            }
         };
 
         server.Start(cancellationToken);
@@ -918,6 +928,10 @@ public class GuiCommand : IWithConfigCommand
 
             if (toNotify.Count > 0)
             {
+                // Deliberate at-most-once ordering: mark as notified BEFORE sending webhooks.
+                // If a webhook call fails, the invoice is still marked and will not be retried.
+                // This avoids duplicate notifications on transient errors at the cost of
+                // potentially missing one delivery. Change order here if at-least-once is preferred.
                 _invoiceCache.MarkAsNotified(profileKey, toNotify);
                 string? slackUrl = profilePrefs?.SlackWebhookUrl;
                 string? teamsUrl = profilePrefs?.TeamsWebhookUrl;
@@ -946,7 +960,7 @@ public class GuiCommand : IWithConfigCommand
                 Log.LogWarning($"[slack-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
             }
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (HttpRequestException ex)
         {
             Log.LogWarning($"[slack-notify] Failed for profile '{profileName}': {ex.Message}");
@@ -974,7 +988,7 @@ public class GuiCommand : IWithConfigCommand
                 Log.LogWarning($"[teams-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
             }
         }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (HttpRequestException ex)
         {
             Log.LogWarning($"[teams-notify] Failed for profile '{profileName}': {ex.Message}");

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -608,11 +608,11 @@ public class GuiCommand : IWithConfigCommand
             List<(string Name, Task Task)> tasks = [];
             if (!string.IsNullOrEmpty(slackUrl))
             {
-                tasks.Add(("Slack", SendSlackNotificationAsync(slackUrl, profileName, 3, ct)));
+                tasks.Add(("Slack", SendSlackNotificationAsync(slackUrl, profileName, 3, ct, throwOnHttpError: true)));
             }
             if (!string.IsNullOrEmpty(teamsUrl))
             {
-                tasks.Add(("Teams", SendTeamsNotificationAsync(teamsUrl, profileName, 3, ct)));
+                tasks.Add(("Teams", SendTeamsNotificationAsync(teamsUrl, profileName, 3, ct, throwOnHttpError: true)));
             }
             if (tasks.Count == 0)
             {
@@ -947,7 +947,7 @@ public class GuiCommand : IWithConfigCommand
         }
     }
 
-    private static async Task SendSlackNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct)
+    private static async Task SendSlackNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct, bool throwOnHttpError = false)
     {
         string text = $"KSeF: {newCount} nowych faktur dla profilu {profileName}";
         string json = JsonSerializer.Serialize(new { text });
@@ -957,17 +957,25 @@ public class GuiCommand : IWithConfigCommand
             using HttpResponseMessage resp = await _httpClient.PostAsync(webhookUrl, content, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
+                if (throwOnHttpError)
+                {
+                    string body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    throw new HttpRequestException(
+                        $"HTTP {(int)resp.StatusCode}: {body.Trim()}",
+                        null,
+                        resp.StatusCode);
+                }
                 Log.LogWarning($"[slack-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
-        catch (HttpRequestException ex)
+        catch (HttpRequestException ex) when (!throwOnHttpError)
         {
             Log.LogWarning($"[slack-notify] Failed for profile '{profileName}': {ex.Message}");
         }
     }
 
-    private static async Task SendTeamsNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct)
+    private static async Task SendTeamsNotificationAsync(string webhookUrl, string profileName, int newCount, CancellationToken ct, bool throwOnHttpError = false)
     {
         Dictionary<string, object> payload = new()
         {
@@ -985,11 +993,19 @@ public class GuiCommand : IWithConfigCommand
             using HttpResponseMessage resp = await _httpClient.PostAsync(webhookUrl, content, ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
             {
+                if (throwOnHttpError)
+                {
+                    string body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    throw new HttpRequestException(
+                        $"HTTP {(int)resp.StatusCode}: {body.Trim()}",
+                        null,
+                        resp.StatusCode);
+                }
                 Log.LogWarning($"[teams-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
             }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
-        catch (HttpRequestException ex)
+        catch (HttpRequestException ex) when (!throwOnHttpError)
         {
             Log.LogWarning($"[teams-notify] Failed for profile '{profileName}': {ex.Message}");
         }

--- a/src/KSeFCli/IWithConfigCommand.cs
+++ b/src/KSeFCli/IWithConfigCommand.cs
@@ -365,8 +365,9 @@ public abstract class IWithConfigCommand : IGlobalCommand
 
     /// <summary>
     /// Gets (or refreshes) the access token for an arbitrary named profile without affecting
-    /// <see cref="ActiveProfile"/>. Throws if no valid refresh token is stored — the user must
-    /// authenticate that profile interactively at least once before background refresh works.
+    /// <see cref="ActiveProfile"/>. If no valid token is stored, performs initial authentication
+    /// via <see cref="Auth"/> using the supplied profile config, stores the result, and returns
+    /// the obtained access token. If a token is present but near expiry, refreshes it instead.
     /// </summary>
     public async Task<string> GetAccessTokenForProfile(
         string profileName, ProfileConfig profile, IServiceScope scope, CancellationToken ct)

--- a/src/KSeFCli/IWithConfigCommand.cs
+++ b/src/KSeFCli/IWithConfigCommand.cs
@@ -161,22 +161,22 @@ public abstract class IWithConfigCommand : IGlobalCommand
 
     public abstract Task<int> ExecuteInScopeAsync(IServiceScope scope, CancellationToken cancellationToken);
 
-    public async Task<AuthenticationOperationStatusResponse> Auth(IServiceScope scope, CancellationToken cancellationToken)
+    public async Task<AuthenticationOperationStatusResponse> Auth(IServiceScope scope, CancellationToken cancellationToken, ProfileConfig? profileOverride = null)
     {
-        ProfileConfig config = Config();
+        ProfileConfig config = profileOverride ?? Config();
         AuthenticationOperationStatusResponse response = config.AuthMethod switch
         {
-            AuthMethod.KsefToken => await TokenAuth(scope, cancellationToken).ConfigureAwait(false),
-            AuthMethod.Xades => await CertAuth(scope, cancellationToken).ConfigureAwait(false),
+            AuthMethod.KsefToken => await TokenAuth(scope, cancellationToken, profileOverride).ConfigureAwait(false),
+            AuthMethod.Xades => await CertAuth(scope, cancellationToken, profileOverride).ConfigureAwait(false),
             _ => throw new Exception($"Invalid authmethod in profile: {config.Environment}")
         };
         Log.LogInformation($"Access token valid until: {response.AccessToken.ValidUntil} . Refresh token valid until: {response.RefreshToken.ValidUntil}");
         return response;
     }
 
-    public async Task<AuthenticationOperationStatusResponse> TokenAuth(IServiceScope scope, CancellationToken cancellationToken)
+    public async Task<AuthenticationOperationStatusResponse> TokenAuth(IServiceScope scope, CancellationToken cancellationToken, ProfileConfig? profileOverride = null)
     {
-        ProfileConfig config = Config();
+        ProfileConfig config = profileOverride ?? Config();
         if (config.AuthMethod != AuthMethod.KsefToken)
         {
             throw new InvalidOperationException("This command requires token authentication.");
@@ -233,9 +233,9 @@ public abstract class IWithConfigCommand : IGlobalCommand
         return tokenResponse;
     }
 
-    public async Task<AuthenticationOperationStatusResponse> CertAuth(IServiceScope scope, CancellationToken cancellationToken)
+    public async Task<AuthenticationOperationStatusResponse> CertAuth(IServiceScope scope, CancellationToken cancellationToken, ProfileConfig? profileOverride = null)
     {
-        ProfileConfig config = Config();
+        ProfileConfig config = profileOverride ?? Config();
         if (config.AuthMethod != AuthMethod.Xades)
         {
             throw new InvalidOperationException("This command requires certificate authentication.");
@@ -377,8 +377,10 @@ public abstract class IWithConfigCommand : IGlobalCommand
 
         if (stored == null || stored.Response.RefreshToken.ValidUntil < DateTime.UtcNow.AddMinutes(1))
         {
-            throw new InvalidOperationException(
-                $"No valid refresh token for profile '{profileName}' — user must authenticate via GUI first");
+            Log.LogInformation($"[bg-refresh] No stored token for '{profileName}', performing initial authentication...");
+            AuthenticationOperationStatusResponse authResponse = await Auth(scope, ct, profile).ConfigureAwait(false);
+            tokenStore.SetToken(key, new TokenStore.Data(authResponse));
+            return authResponse.AccessToken.Token;
         }
 
         if (stored.Response.AccessToken.ValidUntil < DateTime.UtcNow.AddMinutes(10))

--- a/src/KSeFCli/IWithConfigCommand.cs
+++ b/src/KSeFCli/IWithConfigCommand.cs
@@ -208,7 +208,7 @@ public abstract class IWithConfigCommand : IGlobalCommand
             EncryptedToken = encryptedTokenB64,
             AuthorizationPolicy = null
         };
-        SignatureResponse signature = await ksefClient.SubmitKsefTokenAuthRequestAsync(request, new CancellationToken()).ConfigureAwait(false);
+        SignatureResponse signature = await ksefClient.SubmitKsefTokenAuthRequestAsync(request, cancellationToken).ConfigureAwait(false);
         Log.LogInformation("4. Checking authentication status");
         DateTime startTime = DateTime.UtcNow;
         TimeSpan timeout = TimeSpan.FromMinutes(2);

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -215,20 +215,22 @@ internal sealed class InvoiceCache
             INSERT OR IGNORE INTO notification_sent (profile_key, ksef_number, sent_at)
             VALUES (@key, @ksef, @at)
             """;
-        int count = 0;
+        SqliteParameter pKey = cmd.Parameters.Add("@key", SqliteType.Text);
+        SqliteParameter pKsef = cmd.Parameters.Add("@ksef", SqliteType.Text);
+        SqliteParameter pAt = cmd.Parameters.Add("@at", SqliteType.Text);
+        pKey.Value = profileKey;
+        pAt.Value = sentAt;
+        cmd.Prepare();
+        int inserted = 0;
         foreach (string ksefNumber in ksefNumbers)
         {
-            cmd.Parameters.Clear();
-            cmd.Parameters.AddWithValue("@key", profileKey);
-            cmd.Parameters.AddWithValue("@ksef", ksefNumber);
-            cmd.Parameters.AddWithValue("@at", sentAt);
-            cmd.ExecuteNonQuery();
-            count++;
+            pKsef.Value = ksefNumber;
+            inserted += cmd.ExecuteNonQuery();
         }
         tx.Commit();
-        if (count > 0)
+        if (inserted > 0)
         {
-            Log.LogDebug($"[notif-sent] Marked {count} invoice(s) as notified for profile key {profileKey[..Math.Min(24, profileKey.Length)]}…");
+            Log.LogDebug($"[notif-sent] Marked {inserted} invoice(s) as notified for profile key {profileKey[..Math.Min(24, profileKey.Length)]}…");
         }
     }
 

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -186,6 +186,7 @@ internal sealed class InvoiceCache
     /// </summary>
     public HashSet<string> LoadNotifiedKsefNumbers(string profileKey)
     {
+        PruneNotificationSent();
         using SqliteConnection conn = Open();
         using SqliteCommand cmd = conn.CreateCommand();
         cmd.CommandText = "SELECT ksef_number FROM notification_sent WHERE profile_key = @key";
@@ -232,6 +233,25 @@ internal sealed class InvoiceCache
         {
             Log.LogDebug($"[notif-sent] Marked {inserted} invoice(s) as notified for profile key {profileKey[..Math.Min(24, profileKey.Length)]}…");
         }
+    }
+
+    /// <summary>
+    /// Deletes notification_sent rows older than <paramref name="retentionDays"/> days.
+    /// Call periodically (e.g. at startup or each refresh cycle) to keep the table bounded.
+    /// </summary>
+    public int PruneNotificationSent(int retentionDays = 90)
+    {
+        string cutoff = DateTime.UtcNow.AddDays(-retentionDays).ToString("o");
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM notification_sent WHERE sent_at < @cutoff";
+        cmd.Parameters.AddWithValue("@cutoff", cutoff);
+        int deleted = cmd.ExecuteNonQuery();
+        if (deleted > 0)
+        {
+            Log.LogInformation($"[notif-sent] Pruned {deleted} row(s) older than {retentionDays} days.");
+        }
+        return deleted;
     }
 
     private SqliteConnection Open()

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -52,6 +52,17 @@ internal sealed class InvoiceCache
             """;
         createCmd.ExecuteNonQuery();
 
+        using SqliteCommand notifCmd = conn.CreateCommand();
+        notifCmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS notification_sent (
+                profile_key TEXT NOT NULL,
+                ksef_number TEXT NOT NULL,
+                sent_at     TEXT NOT NULL,
+                PRIMARY KEY (profile_key, ksef_number)
+            )
+            """;
+        notifCmd.ExecuteNonQuery();
+
         // Log per-profile row summary for diagnostics
         using SqliteCommand statsCmd = conn.CreateCommand();
         statsCmd.CommandText = "SELECT profile_key, fetched_at, length(invoices_json) FROM invoice_cache ORDER BY fetched_at DESC";
@@ -166,6 +177,58 @@ internal sealed class InvoiceCache
         if (affected > 0)
         {
             Log.LogInformation($"[cache] WRITE (invoices only) — {invoices.Count} invoices updated in DB ({invoicesJson.Length / 1024.0:F1} KB, profile key {profileKey[..Math.Min(24, profileKey.Length)]}…)");
+        }
+    }
+
+    /// <summary>
+    /// Returns the set of KSeF invoice numbers for which a webhook notification has already been sent
+    /// for this profile. Used to avoid duplicate notifications across refresh cycles.
+    /// </summary>
+    public HashSet<string> LoadNotifiedKsefNumbers(string profileKey)
+    {
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT ksef_number FROM notification_sent WHERE profile_key = @key";
+        cmd.Parameters.AddWithValue("@key", profileKey);
+        using SqliteDataReader reader = cmd.ExecuteReader();
+        HashSet<string> result = [];
+        while (reader.Read())
+        {
+            result.Add(reader.GetString(0));
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Marks the given KSeF invoice numbers as notified for this profile so they are not
+    /// re-notified in future refresh cycles. Also used to seed the baseline on first run
+    /// (without sending any notification) to avoid blasting the full invoice history.
+    /// </summary>
+    public void MarkAsNotified(string profileKey, IEnumerable<string> ksefNumbers)
+    {
+        string sentAt = DateTime.UtcNow.ToString("o");
+        using SqliteConnection conn = Open();
+        using SqliteTransaction tx = conn.BeginTransaction();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText = """
+            INSERT OR IGNORE INTO notification_sent (profile_key, ksef_number, sent_at)
+            VALUES (@key, @ksef, @at)
+            """;
+        int count = 0;
+        foreach (string ksefNumber in ksefNumbers)
+        {
+            cmd.Parameters.Clear();
+            cmd.Parameters.AddWithValue("@key", profileKey);
+            cmd.Parameters.AddWithValue("@ksef", ksefNumber);
+            cmd.Parameters.AddWithValue("@at", sentAt);
+            cmd.ExecuteNonQuery();
+            count++;
+        }
+        tx.Commit();
+        if (count > 0)
+        {
+            Log.LogDebug($"[notif-sent] Marked {count} invoice(s) as notified for profile key {profileKey[..Math.Min(24, profileKey.Length)]}…");
         }
     }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1410,11 +1410,11 @@ function renderProfileCard(p, i) {
     '</div>' +
     '<div class="cfg-field">' +
     '<label>Slack Webhook URL (opcjonalnie)</label>' +
-    '<input type="text" id="cfgSlackWebhook' + i + '" value="' + esc(p.slackWebhookUrl||'') + '" placeholder="https://hooks.slack.com/services/...">' +
+    '<input type="url" id="cfgSlackWebhook' + i + '" value="' + esc(p.slackWebhookUrl||'') + '" placeholder="https://hooks.slack.com/services/...">' +
     '</div>' +
     '<div class="cfg-field">' +
     '<label>Teams Webhook URL (opcjonalnie)</label>' +
-    '<input type="text" id="cfgTeamsWebhook' + i + '" value="' + esc(p.teamsWebhookUrl||'') + '" placeholder="https://...webhook.office.com/...">' +
+    '<input type="url" id="cfgTeamsWebhook' + i + '" value="' + esc(p.teamsWebhookUrl||'') + '" placeholder="https://...webhook.office.com/...">' +
     '</div>' +
     '<div class="cfg-card-footer">' +
     '<label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.85rem">' +

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -57,6 +57,10 @@ internal sealed class WebProgressServer : IDisposable
     /// <summary>Called to save modified config. Receives JSON string, returns empty string on success or error message.</summary>
     public Func<string, Task<string>>? OnSaveConfig { get; set; }
 
+    /// <summary>Called when user triggers "test notification". Receives profile name, fires webhook(s) if configured.
+    /// Returns empty string on success or a description of what was sent.</summary>
+    public Func<string, Task<string>>? OnTestNotification { get; set; }
+
     public bool Lan { get; }
 
     /// <summary>
@@ -428,6 +432,17 @@ internal sealed class WebProgressServer : IDisposable
                     : JsonSerializer.Serialize(new { ok = false, error });
             }).ConfigureAwait(false);
         }
+        else if (path == "/test-notification" && method == "POST")
+        {
+            await HandleAction(ctx, ct, async () =>
+            {
+                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                string result = OnTestNotification != null
+                    ? await OnTestNotification(body).ConfigureAwait(false)
+                    : "";
+                return JsonSerializer.Serialize(new { ok = true, message = result });
+            }).ConfigureAwait(false);
+        }
         else if (path == "/quit" && method == "POST")
         {
             ctx.Response.StatusCode = 200;
@@ -500,7 +515,7 @@ h1{font-size:1.3rem;margin-bottom:1rem}
 .field{display:flex;flex-direction:column;gap:.2rem}
 .field label{font-size:.75rem;font-weight:600;color:#555}
 .field select,.field input{padding:.4rem .6rem;border:1px solid #ccc;border-radius:4px;font-size:.85rem}
-.field input{width:140px}
+.field input{width:140px}.field input[type=month]{width:160px}
 button{padding:.5rem 1.2rem;border:none;border-radius:6px;font-size:.9rem;font-weight:600;cursor:pointer;transition:background .15s,opacity .15s}
 button:disabled{opacity:.4;cursor:default}
 .btn-primary{background:#1976d2;color:#fff}
@@ -1391,6 +1406,14 @@ function renderProfileCard(p, i) {
     '<div class="cfg-field"><label>Haslo z pliku (opcjonalnie)</label>' +
     '<input type="text" id="cfgCertPassFile' + i + '" value="' + esc(p.certPasswordFile||'') + '" placeholder="~/password.txt"></div>' +
     '</div>' +
+    '<div class="cfg-field">' +
+    '<label>Slack Webhook URL (opcjonalnie)</label>' +
+    '<input type="text" id="cfgSlackWebhook' + i + '" value="' + esc(p.slackWebhookUrl||'') + '" placeholder="https://hooks.slack.com/services/...">' +
+    '</div>' +
+    '<div class="cfg-field">' +
+    '<label>Teams Webhook URL (opcjonalnie)</label>' +
+    '<input type="text" id="cfgTeamsWebhook' + i + '" value="' + esc(p.teamsWebhookUrl||'') + '" placeholder="https://...webhook.office.com/...">' +
+    '</div>' +
     '<div class="cfg-card-footer">' +
     '<label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.85rem">' +
     '<input type="checkbox" id="cfgAutoRefresh' + i + '"' + (p.includeInAutoRefresh ? ' checked' : '') + '>' +
@@ -1468,6 +1491,8 @@ function deleteProfile(i) {
       certPasswordEnv: am === 'certificate' ? (document.getElementById('cfgCertPassEnv' + j)?.value || null) : null,
       certPasswordFile: am === 'certificate' ? (document.getElementById('cfgCertPassFile' + j)?.value || null) : null,
       includeInAutoRefresh: document.getElementById('cfgAutoRefresh' + j)?.checked ?? cfgData.profiles[j].includeInAutoRefresh,
+      slackWebhookUrl: document.getElementById('cfgSlackWebhook' + j)?.value || null,
+      teamsWebhookUrl: document.getElementById('cfgTeamsWebhook' + j)?.value || null,
     };
   }
   // If deleting the active profile, reassign to the nearest remaining one
@@ -1500,6 +1525,8 @@ async function saveConfigEditor() {
       certPasswordEnv: authMethod === 'certificate' ? (document.getElementById('cfgCertPassEnv' + i)?.value || null) : null,
       certPasswordFile: authMethod === 'certificate' ? (document.getElementById('cfgCertPassFile' + i)?.value || null) : null,
       includeInAutoRefresh: document.getElementById('cfgAutoRefresh' + i)?.checked || false,
+      slackWebhookUrl: document.getElementById('cfgSlackWebhook' + i)?.value || null,
+      teamsWebhookUrl: document.getElementById('cfgTeamsWebhook' + i)?.value || null,
     });
   }
   const payload = { activeProfile, configFilePath: cfgData.configFilePath, profiles };
@@ -1508,13 +1535,11 @@ async function saveConfigEditor() {
     const data = await res.json();
     if (data.ok) {
       cfgData = payload;
-      $('cfgSaveMsg').textContent = 'Zapisano!';
-      $('cfgSaveMsg').style.display = '';
-      setTimeout(() => { $('cfgSaveMsg').style.display = 'none'; }, 3000);
       // Refresh profile dropdown and token status (new/edited profile = new token state)
       await loadPrefs();
       applySetupMode(false);
       await fetchTokenStatus();
+      closeConfigEditor();
     } else {
       $('cfgErrMsg').textContent = data.error || 'Nieznany blad';
       $('cfgErrMsg').style.display = '';
@@ -1989,7 +2014,7 @@ function requestNotificationPermission() {
   }
 }
 
-function sendSampleNotification() {
+async function sendSampleNotification() {
   requestNotificationPermission();
   const msg = 'Znaleziono 3 nowe faktury!';
   // 1. Page title badge
@@ -2001,6 +2026,19 @@ function sendSampleNotification() {
   if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
     new Notification('KSeFCli', { body: msg });
   }
+  // 4. Webhook channels (Slack / Teams) configured for the current profile
+  try {
+    const profileName = (typeof currentSessionProfile !== 'undefined' ? currentSessionProfile : '') || '';
+    const res = await fetch('/test-notification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileName }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.message) showNewInvoiceToast('Webhook: ' + data.message);
+    }
+  } catch (e) { /* ignore webhook test errors */ }
 }
 
 async function doDownload(selOnly) {

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -59,7 +59,7 @@ internal sealed class WebProgressServer : IDisposable
 
     /// <summary>Called when user triggers "test notification". Receives profile name, fires webhook(s) if configured.
     /// Returns empty string on success or a description of what was sent.</summary>
-    public Func<string, Task<string>>? OnTestNotification { get; set; }
+    public Func<string, CancellationToken, Task<string>>? OnTestNotification { get; set; }
 
     public bool Lan { get; }
 
@@ -423,7 +423,8 @@ internal sealed class WebProgressServer : IDisposable
         {
             await HandleAction(ctx, ct, async () =>
             {
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader reader1 = new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await reader1.ReadToEndAsync(ct).ConfigureAwait(false);
                 string error = OnSaveConfig != null
                     ? await OnSaveConfig(body).ConfigureAwait(false)
                     : "";
@@ -436,9 +437,10 @@ internal sealed class WebProgressServer : IDisposable
         {
             await HandleAction(ctx, ct, async () =>
             {
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader reader2 = new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await reader2.ReadToEndAsync(ct).ConfigureAwait(false);
                 string result = OnTestNotification != null
-                    ? await OnTestNotification(body).ConfigureAwait(false)
+                    ? await OnTestNotification(body, ct).ConfigureAwait(false)
                     : "";
                 return JsonSerializer.Serialize(new { ok = true, message = result });
             }).ConfigureAwait(false);


### PR DESCRIPTION
Implements Slack and Teams webhook integration for invoice notifications
- Adds webhook URL configuration fields to profile settings
- Creates notification tracking to prevent duplicate messages
- Sends notifications only for genuinely new invoices
- Includes test notification functionality in GUI
- Handles automatic authentication for background refreshes
- Seeds notification baseline on first run to avoid spam

Enables real-time alerts when new invoices are detected during automated profile refreshes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile Slack and Teams webhook fields added to the config UI and persisted.
  * Test-notification action to send and validate sample webhooks per profile with feedback.
  * Background refresh triggers per-profile webhook notifications for newly discovered invoices.
  * Notification state tracked per profile (with pruning/retention) and initial seeding to avoid mass alerts.

* **Bug Fixes**
  * Improved authentication flow to obtain and store access tokens during profile setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->