### PR TITLE
fix: improves preferences modal UX and data handling

### DIFF
--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -716,7 +716,8 @@ public class GuiCommand : IWithConfigCommand
         IKSeFClient client,
         InvoiceQueryFilters filters,
         string accessToken,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool abortOn429 = false)
     {
         List<InvoiceSummary> all = new();
         PagedInvoiceResponse pagedResponse;
@@ -740,7 +741,7 @@ public class GuiCommand : IWithConfigCommand
                         cancellationToken: ct).ConfigureAwait(false);
                     break;
                 }
-                catch (KsefRateLimitException ex) when (attempt < maxRetries)
+                catch (KsefRateLimitException ex) when (attempt < maxRetries && !abortOn429)
                 {
                     TimeSpan delay = ex.RecommendedDelay + TimeSpan.FromSeconds(attempt * 2);
                     Log.LogWarning($"Rate limited (HTTP 429). Retrying in {delay.TotalSeconds:F0}s... (attempt {attempt + 1}/{maxRetries})");
@@ -852,22 +853,30 @@ public class GuiCommand : IWithConfigCommand
             catch { continue; }
 
             Dictionary<string, ProfilePrefs> ppMap = prefs.ProfilePrefs ?? [];
+            string snapshotActive = ActiveProfile; // snapshot to catch mid-loop changes
+            Log.LogDebug($"[bg-refresh] Cycle start — activeProfile='{snapshotActive}', profiles=[{string.Join(", ", config.Profiles.Keys)}]");
             foreach ((string name, ProfileConfig profile) in config.Profiles)
             {
-                if (name == ActiveProfile)
+                if (name == snapshotActive)
                 {
+                    Log.LogDebug($"[bg-refresh] Skipping '{name}' (active profile, handled by JS)");
                     continue; // JS silentRefresh handles the active profile
                 }
 
                 ProfilePrefs? profilePrefs = ppMap.TryGetValue(name, out ProfilePrefs? pp) ? pp : null;
                 if (profilePrefs?.IncludeInAutoRefresh == false)
                 {
+                    Log.LogDebug($"[bg-refresh] Skipping '{name}' (includeInAutoRefresh=false)");
                     continue;
                 }
 
                 try
                 {
                     await RefreshProfileInBackgroundAsync(name, profile, profilePrefs, ct).ConfigureAwait(false);
+                }
+                catch (KsefRateLimitException ex)
+                {
+                    Log.LogWarning($"[bg-refresh] Profile '{name}': rate-limited (retry-after {ex.RecommendedDelay.TotalSeconds:F0}s) — skipping this cycle");
                 }
                 catch (Exception ex)
                 {
@@ -892,7 +901,7 @@ public class GuiCommand : IWithConfigCommand
         InvoiceQueryFilters filters = await BuildFiltersAsync(sp, ct).ConfigureAwait(false);
 
         IKSeFClient client = scope.ServiceProvider.GetRequiredService<IKSeFClient>();
-        List<InvoiceSummary> invoices = await FetchAllPagesAsync(client, filters, accessToken, ct).ConfigureAwait(false);
+        List<InvoiceSummary> invoices = await FetchAllPagesAsync(client, filters, accessToken, ct, abortOn429: true).ConfigureAwait(false);
 
         if (prev == null)
         {

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -282,6 +282,8 @@ public class GuiCommand : IWithConfigCommand
             string? newProfile = root.TryGetProperty("selectedProfile", out JsonElement sp) ? sp.GetString() : null;
             bool jsonConsoleLog = root.TryGetProperty("jsonConsoleLog", out JsonElement jcl) && jcl.GetBoolean();
             Log.LogDebug($"SavePrefs: selectedProfile={newProfile ?? "(null)"}, activeProfile={ActiveProfile}, switching={!string.IsNullOrEmpty(newProfile) && newProfile != ActiveProfile}");
+            // Load existing prefs first so we can preserve fields not sent by JS (e.g. ProfilePrefs with webhook URLs).
+            GuiPrefs existingPrefs = LoadPrefs();
             SavePrefs(new GuiPrefs(
                 OutputDir: root.TryGetProperty("outputDir", out JsonElement od) ? od.GetString() : null,
                 ExportXml: root.TryGetProperty("exportXml", out JsonElement ex) ? ex.GetBoolean() : null,
@@ -299,11 +301,9 @@ public class GuiCommand : IWithConfigCommand
                 AutoRefreshMinutes: root.TryGetProperty("autoRefreshMinutes", out JsonElement arm) ? arm.GetInt32() : null,
                 JsonConsoleLog: jsonConsoleLog,
                 DisplayLimit: root.TryGetProperty("displayLimit", out JsonElement dl) ? dl.GetInt32() : null,
-                ProfilePrefs: root.TryGetProperty("profilePrefs", out JsonElement pp)
-                    ? JsonSerializer.Deserialize<Dictionary<string, ProfilePrefs>>(
-                        pp.GetRawText(),
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
-                    : null
+                // Preserve ProfilePrefs from disk — JS savePrefs() never sends it,
+                // so this prevents webhook URLs from being wiped on every prefs save.
+                ProfilePrefs: existingPrefs.ProfilePrefs
             ));
             Log.ConfigureLogging(Verbose, Quiet, jsonConsoleLog);
             if (!string.IsNullOrEmpty(newProfile) && newProfile != ActiveProfile)

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -870,7 +870,7 @@ body.dark .pref-label{color:#aaa}
   <div class="modal prefs-modal" onclick="event.stopPropagation()">
     <div class="modal-header">
       <h2>&#9881; Preferencje</h2>
-      <button class="modal-close" onclick="cancelPrefs()" title="Anuluj">&times;</button>
+      <button class="modal-close" id="btnClosePrefs" onclick="cancelPrefs()" title="Anuluj">&times;</button>
     </div>
     <div class="prefs-tabs">
       <button class="prefs-tab active" id="ptab-general" onclick="switchPrefsTab('general',this)">Ogólne</button>
@@ -1261,10 +1261,13 @@ async function savePrefs() {
     displayLimit: parseInt($('displayLimit').value) || 50
   };
   const mins = prefs.autoRefreshMinutes;
-  startAutoRefresh(mins);
-  if (mins > 0) requestNotificationPermission();
   const resp = await fetch('/prefs', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prefs) });
   if (!resp.ok) throw new Error('HTTP ' + resp.status);
+  const data = await resp.json();
+  if (data?.error) throw new Error(data.error);
+  // Only mutate runtime state after the save is confirmed on disk
+  startAutoRefresh(mins);
+  if (mins > 0) requestNotificationPermission();
 }
 
 async function onProfileChange() {
@@ -1299,18 +1302,19 @@ function closePrefs() { $('prefsModal').classList.remove('visible'); }
 async function cancelPrefs() { await loadPrefs(); closePrefs(); }
 async function saveAndClosePrefs() {
   const btn = $('btnSavePrefs'), errEl = $('prefsSaveErr');
+  const cancelBtns = [$('btnCancelPrefs'), $('btnClosePrefs')];
   errEl.style.display = 'none';
   btn.disabled = true;
-  $('btnCancelPrefs').disabled = true;
+  cancelBtns.forEach(b => { if (b) b.disabled = true; });
   try {
     await savePrefs();
     closePrefs();
-  } catch {
-    errEl.textContent = 'Błąd zapisu — sprawdź połączenie z serwerem.';
+  } catch (err) {
+    errEl.textContent = 'Błąd zapisu — ' + (err?.message || 'sprawdź połączenie z serwerem.');
     errEl.style.display = '';
   } finally {
     btn.disabled = false;
-    $('btnCancelPrefs').disabled = false;
+    cancelBtns.forEach(b => { if (b) b.disabled = false; });
   }
 }
 function switchPrefsTab(name, btn) {
@@ -2145,7 +2149,8 @@ async function browseTo(path) {
 function selectCurrentDir() {
   $('outputDir').value = browseCurrent;
   closeBrowser();
-  savePrefs().catch(() => {});
+  // No savePrefs() here — the folder browser is used from within the prefs modal,
+  // so persistence is left to the explicit "Zapisz preferencje" button.
 }
 
 async function createDir() {
@@ -2173,7 +2178,14 @@ function closeDetails() {
   if (detailOverlay) { detailOverlay.remove(); detailOverlay = null; }
 }
 
-document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { closeDetails(); $('aboutModal').classList.remove('visible'); } });
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    closeDetails();
+    $('aboutModal').classList.remove('visible');
+    if ($('prefsModal').classList.contains('visible')) cancelPrefs();
+    if ($('configModal').classList.contains('visible')) closeConfigEditor();
+  }
+});
 
 async function showDetails(idx, event) {
   closeDetails();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -983,8 +983,9 @@ body.dark .pref-label{color:#aaa}
       </div>
     </div>
     <div class="modal-footer" style="justify-content:flex-end;gap:.5rem">
-      <button class="btn-sm btn-outline" onclick="cancelPrefs()" style="padding:.4rem 1rem">Anuluj</button>
-      <button class="btn-prefs" onclick="savePrefs();closePrefs()" style="padding:.4rem 1.2rem">Zapisz preferencje</button>
+      <span id="prefsSaveErr" style="display:none;font-size:.8rem;color:#c62828"></span>
+      <button class="btn-sm btn-outline" id="btnCancelPrefs" onclick="cancelPrefs()" style="padding:.4rem 1rem">Anuluj</button>
+      <button class="btn-prefs" id="btnSavePrefs" onclick="saveAndClosePrefs()" style="padding:.4rem 1.2rem">Zapisz preferencje</button>
     </div>
   </div>
 </div>
@@ -1237,7 +1238,7 @@ fetchTokenStatus();
 setInterval(() => { updateAuthButton(); }, 15000);
 setInterval(() => { fetchTokenStatus(); }, 60000);
 
-function savePrefs() {
+async function savePrefs() {
   const prefs = {
     outputDir: $('outputDir').value || '.',
     exportXml: $('expXml').checked,
@@ -1259,7 +1260,8 @@ function savePrefs() {
   const mins = prefs.autoRefreshMinutes;
   startAutoRefresh(mins);
   if (mins > 0) requestNotificationPermission();
-  return fetch('/prefs', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prefs) }).catch(() => {});
+  const resp = await fetch('/prefs', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prefs) });
+  if (!resp.ok) throw new Error('HTTP ' + resp.status);
 }
 
 async function onProfileChange() {
@@ -1268,7 +1270,7 @@ async function onProfileChange() {
     delete profileBadges[chosen];
     updateProfileSelectBadges();
   }
-  await savePrefs();
+  savePrefs().catch(() => {});
   // Clear all results and token status immediately on profile switch
   tableWrap.innerHTML = '';
   invoices = []; total = 0; completed = 0; sortCol = null;
@@ -1291,6 +1293,22 @@ function togglePrefs() { openPrefs(); }
 function openPrefs() { $('prefsModal').classList.add('visible'); }
 function closePrefs() { $('prefsModal').classList.remove('visible'); }
 async function cancelPrefs() { await loadPrefs(); closePrefs(); }
+async function saveAndClosePrefs() {
+  const btn = $('btnSavePrefs'), errEl = $('prefsSaveErr');
+  errEl.style.display = 'none';
+  btn.disabled = true;
+  $('btnCancelPrefs').disabled = true;
+  try {
+    await savePrefs();
+    closePrefs();
+  } catch {
+    errEl.textContent = 'Błąd zapisu — sprawdź połączenie z serwerem.';
+    errEl.style.display = '';
+  } finally {
+    btn.disabled = false;
+    $('btnCancelPrefs').disabled = false;
+  }
+}
 function switchPrefsTab(name, btn) {
   document.querySelectorAll('.prefs-pane').forEach(p => p.style.display = 'none');
   document.querySelectorAll('.prefs-tab').forEach(t => t.classList.remove('active'));
@@ -1703,7 +1721,7 @@ function setDisplayLimit(val) {
   const sel = $('displayLimit');
   if (sel) sel.value = val;
   currentPage = 0;
-  savePrefs();
+  savePrefs().catch(() => {});
   renderTable();
 }
 
@@ -2119,7 +2137,7 @@ async function browseTo(path) {
 function selectCurrentDir() {
   $('outputDir').value = browseCurrent;
   closeBrowser();
-  savePrefs();
+  savePrefs().catch(() => {});
 }
 
 async function createDir() {

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -866,11 +866,11 @@ body.dark .pref-label{color:#aaa}
     <button class="btn-danger" onclick="doQuit()" title="Zamknij serwer GUI" style="margin-left:auto">&#9746; Zakoncz</button>
   </div>
 </div>
-<div class="modal-overlay" id="prefsModal" onclick="onPrefsOverlayClick(event)">
+<div class="modal-overlay" id="prefsModal">
   <div class="modal prefs-modal" onclick="event.stopPropagation()">
     <div class="modal-header">
       <h2>&#9881; Preferencje</h2>
-      <button class="modal-close" onclick="closePrefs()">&times;</button>
+      <button class="modal-close" onclick="cancelPrefs()" title="Anuluj">&times;</button>
     </div>
     <div class="prefs-tabs">
       <button class="prefs-tab active" id="ptab-general" onclick="switchPrefsTab('general',this)">Ogólne</button>
@@ -883,23 +883,23 @@ body.dark .pref-label{color:#aaa}
         <div class="pref-row">
           <span class="pref-label">Katalog wyjściowy</span>
           <div style="display:flex;gap:.3rem">
-            <input id="outputDir" type="text" value="." placeholder="/tmp/faktury" style="width:220px" onchange="savePrefs()">
+            <input id="outputDir" type="text" value="." placeholder="/tmp/faktury" style="width:220px">
             <button class="btn-primary" type="button" onclick="openBrowser()" style="padding:.4rem .6rem;font-size:.8rem" title="Wybierz folder">&#128193;</button>
           </div>
         </div>
         <div class="pref-row">
           <span class="pref-label">Separuj po NIP</span>
-          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="separateByNip" onchange="savePrefs()"> <span id="profileNameLabel"></span></label>
+          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="separateByNip"> <span id="profileNameLabel"></span></label>
         </div>
         <div class="pref-row">
           <span class="pref-label">Nazwy plików</span>
-          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="customFilenames" onchange="savePrefs()"> data-sprzedawca-waluta-ksef</label>
+          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="customFilenames"> data-sprzedawca-waluta-ksef</label>
         </div>
         <div class="pref-row">
           <span class="pref-label">Auto-odświeżanie (min)</span>
           <div style="display:flex;align-items:center;gap:.5rem">
             <input id="autoRefreshMinutes" type="number" value="0" min="0" max="1440" step="1"
-                   style="width:5rem" onchange="savePrefs()"
+                   style="width:5rem"
                    title="0 = wyłączone, 1–1440 minut">
             <span style="font-size:.75rem;color:#999">0 = wyłączone</span>
           </div>
@@ -907,7 +907,7 @@ body.dark .pref-label{color:#aaa}
         <div class="pref-row">
           <span class="pref-label">Wiersze na ekranie</span>
           <div style="display:flex;align-items:center;gap:.5rem">
-            <select id="displayLimit" onchange="savePrefs();renderTable()">
+            <select id="displayLimit" onchange="renderTable()">
               <option value="5">5</option>
               <option value="10">10</option>
               <option value="50" selected>50</option>
@@ -921,7 +921,7 @@ body.dark .pref-label{color:#aaa}
         <div class="pref-row">
           <span class="pref-label">Port nasłuchiwania</span>
           <div style="display:flex;align-items:center;gap:.5rem">
-            <input id="lanPort" type="number" value="18150" min="1024" max="65535" style="width:95px" onchange="savePrefs()">
+            <input id="lanPort" type="number" value="18150" min="1024" max="65535" style="width:95px">
             <span style="font-size:.75rem;color:#999">wymaga restartu</span>
           </div>
         </div>
@@ -929,10 +929,10 @@ body.dark .pref-label{color:#aaa}
           <span class="pref-label">Tryb nasłuchiwania</span>
           <div style="display:flex;flex-direction:column;gap:.4rem;font-size:.85rem">
             <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer">
-              <input type="radio" name="listenMode" id="listenLocal" value="local" onchange="savePrefs()"> Tylko localhost (127.0.0.1)
+              <input type="radio" name="listenMode" id="listenLocal" value="local"> Tylko localhost (127.0.0.1)
             </label>
             <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer">
-              <input type="radio" name="listenMode" id="listenAll" value="all" onchange="savePrefs()"> Sieć lokalna (0.0.0.0) — wymaga restartu
+              <input type="radio" name="listenMode" id="listenAll" value="all"> Sieć lokalna (0.0.0.0) — wymaga restartu
             </label>
           </div>
         </div>
@@ -945,14 +945,14 @@ body.dark .pref-label{color:#aaa}
         <div class="pref-row">
           <span class="pref-label">Formaty eksportu</span>
           <div style="display:flex;gap:.9rem;align-items:center;flex-wrap:wrap">
-            <label style="display:flex;align-items:center;gap:.3rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="expXml" checked onchange="savePrefs()"> XML</label>
-            <label style="display:flex;align-items:center;gap:.3rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="expPdf" checked onchange="savePrefs()"> PDF</label>
-            <label style="display:flex;align-items:center;gap:.3rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="expJson" onchange="savePrefs()"> JSON</label>
+            <label style="display:flex;align-items:center;gap:.3rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="expXml" checked> XML</label>
+            <label style="display:flex;align-items:center;gap:.3rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="expPdf" checked> PDF</label>
+            <label style="display:flex;align-items:center;gap:.3rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="expJson"> JSON</label>
           </div>
         </div>
         <div class="pref-row">
           <span class="pref-label">Schemat kolorów PDF</span>
-          <select id="pdfColorScheme" onchange="savePrefs()">
+          <select id="pdfColorScheme">
             <option value="navy">Granatowy</option>
             <option value="forest">Zielony</option>
             <option value="slate">Szary</option>
@@ -966,11 +966,11 @@ body.dark .pref-label{color:#aaa}
         </div>
         <div class="pref-row">
           <span class="pref-label">Podgląd faktury ciemny</span>
-          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="previewDarkMode" onchange="savePrefs()"> Włącz</label>
+          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="previewDarkMode"> Włącz</label>
         </div>
         <div class="pref-row">
           <span class="pref-label">Szczegóły faktury ciemne</span>
-          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="detailsDarkMode" onchange="savePrefs()"> Włącz</label>
+          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="detailsDarkMode"> Włącz</label>
         </div>
         <div class="pref-row">
           <span class="pref-label">Testuj powiadomienia</span>
@@ -978,11 +978,12 @@ body.dark .pref-label{color:#aaa}
         </div>
         <div class="pref-row">
           <span class="pref-label">Format logów konsoli</span>
-          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="jsonConsoleLog" onchange="savePrefs()"> JSON</label>
+          <label style="display:flex;align-items:center;gap:.4rem;cursor:pointer;font-size:.85rem"><input type="checkbox" id="jsonConsoleLog"> JSON</label>
         </div>
       </div>
     </div>
-    <div class="modal-footer" style="justify-content:flex-end">
+    <div class="modal-footer" style="justify-content:flex-end;gap:.5rem">
+      <button class="btn-sm btn-outline" onclick="cancelPrefs()" style="padding:.4rem 1rem">Anuluj</button>
       <button class="btn-prefs" onclick="savePrefs();closePrefs()" style="padding:.4rem 1.2rem">Zapisz preferencje</button>
     </div>
   </div>
@@ -1026,7 +1027,7 @@ body.dark .pref-label{color:#aaa}
     </div>
   </div>
 </div>
-<div class="modal-overlay" id="configModal" onclick="onConfigModalOverlayClick(event)">
+<div class="modal-overlay" id="configModal">
   <div class="modal cfg-modal" onclick="event.stopPropagation()">
     <div class="modal-header">
       <h2>&#9998; Konfiguracja</h2>
@@ -1040,6 +1041,7 @@ body.dark .pref-label{color:#aaa}
       <span id="cfgSaveMsg" style="font-size:.8rem;color:#2e7d32;display:none"></span>
       <span id="cfgErrMsg" style="font-size:.8rem;color:#c62828;display:none"></span>
       <button class="btn-sm btn-outline" onclick="addProfile()">+ Dodaj profil</button>
+      <button class="btn-sm btn-outline" onclick="closeConfigEditor()" style="padding:.4rem 1rem">Anuluj</button>
       <button class="btn-success" onclick="saveConfigEditor()" style="padding:.4rem 1.2rem">Zapisz</button>
     </div>
   </div>
@@ -1136,9 +1138,9 @@ async function loadPrefs() {
       $('listenLocal').checked = !p.listenOnAll;
       $('listenAll').checked = !!p.listenOnAll;
       if (p.serverUrl) $('serverUrl').textContent = p.serverUrl;
-      if (p.darkMode) { $('darkMode').checked = true; document.body.classList.add('dark'); }
-      if (p.previewDarkMode) { $('previewDarkMode').checked = true; }
-      if (p.detailsDarkMode) { $('detailsDarkMode').checked = true; }
+      $('darkMode').checked = !!p.darkMode; document.body.classList.toggle('dark', !!p.darkMode);
+      $('previewDarkMode').checked = !!p.previewDarkMode;
+      $('detailsDarkMode').checked = !!p.detailsDarkMode;
       if (p.pdfColorScheme) $('pdfColorScheme').value = p.pdfColorScheme;
       if (p.jsonConsoleLog) $('jsonConsoleLog').checked = p.jsonConsoleLog;
       $('autoRefreshMinutes').value = p.autoRefreshMinutes ?? 0;
@@ -1288,7 +1290,7 @@ async function onProfileChange() {
 function togglePrefs() { openPrefs(); }
 function openPrefs() { $('prefsModal').classList.add('visible'); }
 function closePrefs() { $('prefsModal').classList.remove('visible'); }
-function onPrefsOverlayClick(e) { if (e.target === $('prefsModal')) closePrefs(); }
+async function cancelPrefs() { await loadPrefs(); closePrefs(); }
 function switchPrefsTab(name, btn) {
   document.querySelectorAll('.prefs-pane').forEach(p => p.style.display = 'none');
   document.querySelectorAll('.prefs-tab').forEach(t => t.classList.remove('active'));
@@ -1341,10 +1343,6 @@ async function openAbout() {
   } catch(e) {
     $('aboutBody').innerHTML = '<span style="color:#c62828">Błąd: ' + escHtml(e.message) + '</span>';
   }
-}
-
-function onConfigModalOverlayClick(e) {
-  if (e.target === $('configModal')) closeConfigEditor();
 }
 
 function renderConfigEditor() {
@@ -1558,7 +1556,6 @@ function esc(s) {
 
 function toggleDarkMode() {
   document.body.classList.toggle('dark', $('darkMode').checked);
-  savePrefs();
 }
 
 function setStatus(text, cls) { status.textContent = text; status.className = 'status ' + cls; }
@@ -2150,7 +2147,7 @@ function closeDetails() {
   if (detailOverlay) { detailOverlay.remove(); detailOverlay = null; }
 }
 
-document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { closeDetails(); closeConfigEditor(); } });
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') { closeDetails(); $('aboutModal').classList.remove('visible'); } });
 
 async function showDetails(idx, event) {
   closeDetails();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1066,6 +1066,7 @@ const status = $('status'), bar = $('bar'), progressWrap = $('progressWrap'),
       btnSearch = $('btnSearch'), btnDownload = $('btnDownload'), btnDownloadSel = $('btnDownloadSel'),
       countLabel = $('countLabel');
 let invoices = [], total = 0, completed = 0, sortCol = null, sortAsc = true, es = null;
+let profileSwitchGen = 0; // incremented on every profile switch; stale async results discard themselves
 let activeCurrencies = new Set();
 let selectedInvoices = new Set();
 let fileStatus = [];
@@ -1089,10 +1090,12 @@ let lastSearchParams = null;        // params of last successful search; null = 
 })();
 
 async function loadCachedInvoices() {
+  const myGen = profileSwitchGen;
   try {
     const res = await fetch('/cached-invoices');
     if (!res.ok) return;
     const data = await res.json();
+    if (profileSwitchGen !== myGen) return; // profile switched while fetching — discard stale result
     if (!data.invoices || data.invoices.length === 0) return;
     invoices = data.invoices;
     for (let i = 0; i < invoices.length; i++) invoices[i]._idx = i;
@@ -1270,7 +1273,8 @@ async function onProfileChange() {
     delete profileBadges[chosen];
     updateProfileSelectBadges();
   }
-  savePrefs().catch(() => {});
+  profileSwitchGen++; // invalidate any in-flight /search or /cached-invoices results from the old profile
+  await savePrefs().catch(() => {}); // must await so server completes the profile switch before we fetch the new cache
   // Clear all results and token status immediately on profile switch
   tableWrap.innerHTML = '';
   invoices = []; total = 0; completed = 0; sortCol = null;
@@ -1900,6 +1904,7 @@ async function doSearch() {
   selectedInvoices = new Set();
   fileStatus = [];
   filterBar.classList.remove('visible');
+  const myGen = profileSwitchGen;
 
   try {
     const fromVal = $('fromDate').value;
@@ -1912,6 +1917,7 @@ async function doSearch() {
     };
     const res = await fetch('/search', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(params) });
     if (!res.ok) { const e = await res.json(); throw new Error(e.error || 'Search failed'); }
+    if (profileSwitchGen !== myGen) { searchRunning = false; return; } // profile switched — discard
     invoices = await res.json();
     for (let i = 0; i < invoices.length; i++) invoices[i]._idx = i;
     total = invoices.length;
@@ -1947,6 +1953,7 @@ async function silentRefresh() {
   if (!lastSearchParams) return;
   if (refreshRunning) { console.info('[auto-refresh] Skipping — previous cycle still running'); return; }
   refreshRunning = true;
+  const myGen = profileSwitchGen;
   try {
     // Refresh session token if it expires within 1 minute
     if (tokenExpiry && (tokenExpiry - Date.now()) < 60 * 1000) {
@@ -1975,6 +1982,7 @@ async function silentRefresh() {
     const res = await fetch('/search', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(params) });
     if (!res.ok) { await fetchTokenStatus(); return; }
     const fresh = await res.json();
+    if (profileSwitchGen !== myGen) return; // profile switched while request was in-flight — discard
     fresh.forEach((inv, i) => inv._idx = i);
     console.info('[auto-refresh] Cyclic search complete —', fresh.length, 'invoices');
     detectNewInvoices(fresh);

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1276,8 +1276,15 @@ async function onProfileChange() {
     delete profileBadges[chosen];
     updateProfileSelectBadges();
   }
-  profileSwitchGen++; // invalidate any in-flight /search or /cached-invoices results from the old profile
-  await savePrefs().catch(() => {}); // must await so server completes the profile switch before we fetch the new cache
+  try {
+    await savePrefs(); // commits the new active profile to the server; must succeed before any UI change
+  } catch (err) {
+    $('profileSelect').value = currentSessionProfile; // revert dropdown to last known-good profile
+    setStatus('Błąd zmiany profilu: ' + err.message, 'error');
+    return; // abort — server still has the old profile; do not clear UI or load wrong cache
+  }
+  profileSwitchGen++; // server confirmed switch; invalidate in-flight results from the old profile
+  currentSessionProfile = chosen; // keep in sync with what server confirmed
   // Clear all results and token status immediately on profile switch
   tableWrap.innerHTML = '';
   invoices = []; total = 0; completed = 0; sortCol = null;


### PR DESCRIPTION
Preserves profile preferences when saving GUI settings to prevent webhook URLs from being wiped on every save operation

Enhances modal interaction by removing auto-save behavior and adding explicit save/cancel buttons for better user control

Updates preference loading logic to merge existing data with new changes rather than overwriting everything

Removes overlay click-to-close functionality to prevent accidental dialog dismissal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preferences (including webhook URLs and other fields) are preserved when saving, preventing accidental wipes.

* **Refactor**
  * Preferences and config now require explicit Save; inputs no longer auto-save on change.
  * Profile-switch flow hardened to avoid stale async results.

* **Behavior**
  * Background profile refresh is more stable: it skips the active profile, handles rate-limit skips without failing the cycle, and adds clearer debug logging.

* **Style**
  * Preferences/config modals updated with dedicated footer, Cancel and Save actions, and inline error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->