### PR TITLE
feat: adds auto-refresh date range controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,6 @@ Wklej adres Incoming Webhook Slacka w polu **Slack Webhook URL** dla danego prof
 https://hooks.slack.com/services/T.../B.../...
 ```
 
-Każde wykrycie nowych faktur wysyła wiadomość na skonfigurowany kanał:
-
-```
-KSeF: 3 nowych faktur dla profilu firma1
-```
-
 #### Microsoft Teams
 
 Wklej adres Incoming Webhook Teams w polu **Teams Webhook URL** dla danego profilu.
@@ -180,30 +174,50 @@ Wklej adres Incoming Webhook Teams w polu **Teams Webhook URL** dla danego profi
 https://xxx.webhook.office.com/webhookb2/...
 ```
 
-Wiadomość wysyłana jest jako **MessageCard** z tytułem i liczbą nowych faktur.
-
 #### E-mail (SMTP)
 
-Skonfiguruj serwer SMTP w **Preferencjach** (ikona ⚙ Preferencje):
+Skonfiguruj serwer SMTP w **Preferencjach** (zakładka **Email**):
 
 | Pole             | Opis                                                        | Domyślnie  |
 | ---------------- | ----------------------------------------------------------- | ---------- |
 | Serwer SMTP      | Adres serwera, np. `smtp.gmail.com`                         | —          |
-| Port             | Port SMTP                                                   | `587`      |
-| Zabezpieczenia   | `StartTLS` — STARTTLS (port 587); `Brak` — bez szyfrowania  | `StartTLS` |
+| Protokół         | `StartTLS` (port 587); `Brak` — bez szyfrowania             | `StartTLS` |
+| Port             | Ustawiany automatycznie po wyborze protokołu                | `587`      |
 | Użytkownik       | Nazwa użytkownika / login                                   | —          |
 | Hasło            | Hasło SMTP lub hasło aplikacji                              | —          |
 | Adres nadawcy    | Nagłówek `From:` (gdy pusty — używany jest login)           | —          |
 
-Adres odbiorcy konfigurowany jest **osobno dla każdego profilu** w edytorze konfiguracji (pole **Adres e-mail powiadomień**).
+Adres odbiorcy konfigurowany jest **osobno dla każdego profilu** w edytorze konfiguracji (pole **Adres e-mail powiadomień**). Zakładka Email zawiera przycisk **Wyślij test** umożliwiający weryfikację konfiguracji — wystarczy podać adres odbiorcy i kliknąć przycisk.
 
 > **Uwaga:** Obsługiwany jest wyłącznie protokół STARTTLS (port 587). Implicit SSL (SMTPS, port 465) nie jest obsługiwany.
 
+#### Rozszerzone powiadomienia
+
+Dla każdego profilu dostępny jest checkbox **Rozszerzone powiadomienia** w edytorze konfiguracji. Gdy włączony, każda wiadomość zawiera szczegóły wykrytych faktur:
+
+| Pole           | Opis                    |
+| -------------- | ----------------------- |
+| Data           | Data wystawienia        |
+| NIP            | NIP sprzedawcy          |
+| Nazwa firmy    | Nazwa sprzedawcy        |
+
+Gdy wyłączony — wysyłana jest tylko informacja o liczbie nowych faktur.
+
 #### Weryfikacja konfiguracji
 
-W edytorze konfiguracji widoczny jest przycisk **🔔 Testuj** dla każdego profilu — wysyła próbną wiadomość do skonfigurowanych kanałów i zwraca wynik (sukces lub błąd z kodem HTTP i treścią odpowiedzi).
+W edytorze konfiguracji widoczny jest przycisk **🔔 Testuj** dla każdego profilu — wysyła próbną wiadomość do skonfigurowanych kanałów i zwraca wynik (sukces lub błąd z kodem HTTP i treścią odpowiedzi). Jeśli włączone są rozszerzone powiadomienia, test wysyłany jest z przykładowymi danymi faktur.
 
 > Powiadomienia wysyłane są wyłącznie dla profili z włączonym **auto-odświeżaniem** (checkbox _Uwzględnij w auto-odświeżaniu_). Każda faktura jest notyfikowana tylko raz (zapisana w bazie SQLite), więc restart aplikacji nie powoduje powtórnych powiadomień.
+
+#### Zakres dat w auto-odświeżaniu
+
+W edytorze konfiguracji dla każdego profilu dostępne są ustawienia sterujące zakresem wyszukiwania podczas auto-odświeżania:
+
+| Ustawienie                                    | Opis                                                                                                    |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| **Auto-odświeżanie: ogranicz do bieżącego miesiąca** | Gdy włączone (domyślnie), data `Od` jest zawsze ustawiana na 1. dzień bieżącego miesiąca — niezależnie od ustawień GUI. Gdy wyłączone, `Od` pochodzi z ostatniego ręcznego wyszukiwania. |
+
+Data `Do` jest zawsze ustawiana na bieżący moment — nigdy nie jest pobierana z GUI, co zapobiega pominięciu faktur po zmianie miesiąca.
 
 ### 🐳 Docker / serwer domowy
 
@@ -428,12 +442,6 @@ Paste an Incoming Webhook URL into the **Slack Webhook URL** field for the profi
 https://hooks.slack.com/services/T.../B.../...
 ```
 
-Each new-invoice detection posts a message to the configured channel:
-
-```
-KSeF: 3 nowych faktur dla profilu company1
-```
-
 #### Microsoft Teams
 
 Paste an Incoming Webhook URL into the **Teams Webhook URL** field for the profile.
@@ -442,30 +450,50 @@ Paste an Incoming Webhook URL into the **Teams Webhook URL** field for the profi
 https://xxx.webhook.office.com/webhookb2/...
 ```
 
-The message is sent as a **MessageCard** with a title and invoice count.
-
 #### E-mail (SMTP)
 
-Configure the SMTP server in **Preferences** (⚙ Preferences icon):
+Configure the SMTP server in **Preferences** (⚙ Preferences icon, **Email** tab):
 
 | Field         | Description                                               | Default    |
 | ------------- | --------------------------------------------------------- | ---------- |
 | SMTP Server   | Server address, e.g. `smtp.gmail.com`                     | —          |
-| Port          | SMTP port                                                 | `587`      |
-| Security      | `StartTLS` — STARTTLS (port 587); `None` — plain          | `StartTLS` |
+| Protocol      | `StartTLS` (port 587); `None` — unencrypted               | `StartTLS` |
+| Port          | Set automatically when protocol is selected               | `587`      |
 | Username      | SMTP username / login                                     | —          |
 | Password      | SMTP password or app password                             | —          |
 | From address  | `From:` header (uses username if empty)                   | —          |
 
-The recipient address is configured **per profile** in the configuration editor (**Notification e-mail** field).
+The recipient address is configured **per profile** in the configuration editor (**Notification e-mail** field). The Email tab also includes a **Send test** button — enter a recipient address and click to verify the SMTP configuration immediately.
 
 > **Note:** Only STARTTLS (port 587) is supported. Implicit SSL (SMTPS, port 465) is not supported.
 
+#### Extended notifications
+
+Each profile has an **Extended notifications** checkbox in the configuration editor. When enabled, notification messages include details of the detected invoices:
+
+| Field        | Description              |
+| ------------ | ------------------------ |
+| Date         | Invoice issue date       |
+| NIP          | Seller's tax ID (NIP)    |
+| Company name | Seller's name            |
+
+When disabled, only the invoice count is included in the notification.
+
 #### Testing the configuration
 
-The configuration editor shows a **🔔 Test** button for each profile — it sends a sample notification to all configured channels and returns the result (success or an HTTP error code with response body).
+The configuration editor shows a **🔔 Test** button for each profile — it sends a sample notification to all configured channels and returns the result (success or an HTTP error code with response body). If extended notifications are enabled, the test is sent with sample invoice data.
 
 > Notifications are sent only for profiles with **auto-refresh enabled** (the _Include in auto-refresh_ checkbox). Each invoice is notified exactly once (tracked in the local SQLite database), so restarting the app does not trigger duplicate notifications.
+
+#### Auto-refresh date range
+
+Each profile in the configuration editor has a setting to control the search date range used during auto-refresh:
+
+| Setting                                    | Description                                                                                                    |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| **Auto-refresh: limit to current month**   | When enabled (default), the `From` date is always set to the 1st of the current month, regardless of GUI settings. When disabled, `From` is taken from the last manual search. |
+
+The `To` date is always set to the current moment — it is never taken from the GUI, which prevents missed invoices after a month boundary.
 
 ### 🐳 Docker / home server
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -978,7 +978,7 @@ public class GuiCommand : IWithConfigCommand
         SearchParams baseParams = cachedParams ?? new SearchParams("Subject2", "thismonth", null, "Issue");
         SearchParams sp = baseParams with
         {
-            From = autoRefreshCurrentMonth ? "thismonth" : baseParams.From,
+            From = autoRefreshCurrentMonth ? "thismonth" : (!string.IsNullOrWhiteSpace(baseParams.From) ? baseParams.From : "thismonth"),
             To = null,
         };
         InvoiceQueryFilters filters = await BuildFiltersAsync(sp, ct).ConfigureAwait(false);

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -585,13 +585,16 @@ public class GuiCommand : IWithConfigCommand
                     ?? new Dictionary<string, ProfilePrefs>();
                 foreach (ProfileEditorData p in data.Profiles)
                 {
+                    // Bool? fields use null to represent the default value, keeping JSON compact.
+                    // ExtendedNotifications default=false  → store true | null
+                    // AutoRefreshCurrentMonth default=true → store null | false
                     updatedPpMap[p.Name] = new ProfilePrefs(
                         IncludeInAutoRefresh: p.IncludeInAutoRefresh,
                         SlackWebhookUrl: string.IsNullOrWhiteSpace(p.SlackWebhookUrl) ? null : p.SlackWebhookUrl,
                         TeamsWebhookUrl: string.IsNullOrWhiteSpace(p.TeamsWebhookUrl) ? null : p.TeamsWebhookUrl,
                         NotificationEmail: string.IsNullOrWhiteSpace(p.NotificationEmail) ? null : p.NotificationEmail,
-                        ExtendedNotifications: p.ExtendedNotifications ? true : null,
-                        AutoRefreshCurrentMonth: p.AutoRefreshCurrentMonth ? null : false);
+                        ExtendedNotifications: p.ExtendedNotifications ? true : null,       // null = false (default)
+                        AutoRefreshCurrentMonth: p.AutoRefreshCurrentMonth ? null : false);  // null = true  (default)
                 }
                 // Remove entries for profiles that no longer exist
                 foreach (string stale in updatedPpMap.Keys.Except(data.Profiles.Select(p => p.Name)).ToList())

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -58,7 +58,8 @@ public class GuiCommand : IWithConfigCommand
         string? SlackWebhookUrl = null,
         string? TeamsWebhookUrl = null,
         string? NotificationEmail = null,
-        bool? ExtendedNotifications = null);
+        bool? ExtendedNotifications = null,
+        bool? AutoRefreshCurrentMonth = null);
 
     private record GuiPrefs(
         string? OutputDir = null,
@@ -100,7 +101,8 @@ public class GuiCommand : IWithConfigCommand
         string? SlackWebhookUrl = null,
         string? TeamsWebhookUrl = null,
         string? NotificationEmail = null,
-        bool ExtendedNotifications = false);
+        bool ExtendedNotifications = false,
+        bool AutoRefreshCurrentMonth = true);
 
     private record ConfigEditorData(
         string ActiveProfile,
@@ -500,7 +502,8 @@ public class GuiCommand : IWithConfigCommand
                     SlackWebhookUrl: pp?.SlackWebhookUrl,
                     TeamsWebhookUrl: pp?.TeamsWebhookUrl,
                     NotificationEmail: pp?.NotificationEmail,
-                    ExtendedNotifications: pp?.ExtendedNotifications ?? false))
+                    ExtendedNotifications: pp?.ExtendedNotifications ?? false,
+                    AutoRefreshCurrentMonth: pp?.AutoRefreshCurrentMonth ?? true))
                 .ToArray();
             return Task.FromResult<object>(new ConfigEditorData(
                 ActiveProfile: rawConfig.ActiveProfile,
@@ -587,7 +590,8 @@ public class GuiCommand : IWithConfigCommand
                         SlackWebhookUrl: string.IsNullOrWhiteSpace(p.SlackWebhookUrl) ? null : p.SlackWebhookUrl,
                         TeamsWebhookUrl: string.IsNullOrWhiteSpace(p.TeamsWebhookUrl) ? null : p.TeamsWebhookUrl,
                         NotificationEmail: string.IsNullOrWhiteSpace(p.NotificationEmail) ? null : p.NotificationEmail,
-                        ExtendedNotifications: p.ExtendedNotifications ? true : null);
+                        ExtendedNotifications: p.ExtendedNotifications ? true : null,
+                        AutoRefreshCurrentMonth: p.AutoRefreshCurrentMonth ? null : false);
                 }
                 // Remove entries for profiles that no longer exist
                 foreach (string stale in updatedPpMap.Keys.Except(data.Profiles.Select(p => p.Name)).ToList())
@@ -964,8 +968,16 @@ public class GuiCommand : IWithConfigCommand
         (List<InvoiceSummary>? prev, SearchParams? cachedParams, _) = _invoiceCache.Load(profileKey);
         HashSet<string> prevKeys = prev?.Select(i => i.KsefNumber).ToHashSet() ?? [];
 
-        // Use last manual search params for this profile, or default to "this month"
-        SearchParams sp = cachedParams ?? new SearchParams("Subject2", "thismonth", null, "Issue");
+        // Use last manual search params for this profile, or default to "this month".
+        // Always clear To: auto-refresh must search up to now(), not a stale GUI date.
+        // Optionally pin From to the start of the current month regardless of GUI setting.
+        bool autoRefreshCurrentMonth = profilePrefs?.AutoRefreshCurrentMonth ?? true;
+        SearchParams baseParams = cachedParams ?? new SearchParams("Subject2", "thismonth", null, "Issue");
+        SearchParams sp = baseParams with
+        {
+            From = autoRefreshCurrentMonth ? "thismonth" : baseParams.From,
+            To = null,
+        };
         InvoiceQueryFilters filters = await BuildFiltersAsync(sp, ct).ConfigureAwait(false);
 
         IKSeFClient client = scope.ServiceProvider.GetRequiredService<IKSeFClient>();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -559,7 +559,7 @@ button:disabled{opacity:.4;cursor:default}
 .cfg-modal{width:600px;max-height:85vh}
 .cfg-profile-card{border:1px solid #ddd;border-radius:8px;padding:.8rem 1rem;margin-bottom:.8rem;position:relative}
 .cfg-profile-card .cfg-card-title{font-weight:600;font-size:.9rem;margin-bottom:.6rem;display:flex;align-items:center;gap:.5rem}
-.cfg-card-footer{display:flex;justify-content:space-between;align-items:center;padding-top:.4rem;border-top:1px solid #ddd}
+.cfg-card-footer{display:flex;justify-content:space-between;align-items:flex-start;padding-top:.4rem;border-top:1px solid #ddd}
 .cfg-field{display:flex;flex-direction:column;margin-bottom:.5rem}
 .cfg-field label{font-size:.75rem;color:#666;margin-bottom:.2rem}
 .cfg-field input,.cfg-field select{padding:.35rem .5rem;border:1px solid #ccc;border-radius:4px;font-size:.85rem}
@@ -1531,13 +1531,18 @@ function renderProfileCard(p, i) {
     '<input type="email" id="cfgNotifEmail' + i + '" value="' + esc(p.notificationEmail||'') + '" placeholder="odbiorca@example.com">' +
     '</div>' +
     '<div class="cfg-card-footer">' +
+    '<div style="display:flex;flex-direction:column;gap:.35rem">' +
     '<label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.85rem">' +
     '<input type="checkbox" id="cfgAutoRefresh' + i + '"' + (p.includeInAutoRefresh ? ' checked' : '') + '>' +
     ' Uwzględnij w auto-odświeżaniu (tło)</label>' +
     '<label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.85rem">' +
+    '<input type="checkbox" id="cfgAutoRefreshCurrentMonth' + i + '"' + (p.autoRefreshCurrentMonth !== false ? ' checked' : '') + '>' +
+    ' Auto-odświeżanie: ogranicz do bieżącego miesiąca</label>' +
+    '<label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.85rem">' +
     '<input type="checkbox" id="cfgExtNotif' + i + '"' + (p.extendedNotifications ? ' checked' : '') + '>' +
     ' Rozszerzone powiadomienia (data, NIP, nazwa firmy)</label>' +
-    '<button type="button" class="btn-sm btn-danger" onclick="deleteProfile(' + i + ')">Usuń profil</button>' +
+    '</div>' +
+    '<button type="button" class="btn-sm btn-danger" onclick="deleteProfile(' + i + ')" style="align-self:flex-end">Usuń profil</button>' +
     '</div>' +
     '</div>';
 }
@@ -1610,6 +1615,7 @@ function deleteProfile(i) {
       certPasswordEnv: am === 'certificate' ? (document.getElementById('cfgCertPassEnv' + j)?.value || null) : null,
       certPasswordFile: am === 'certificate' ? (document.getElementById('cfgCertPassFile' + j)?.value || null) : null,
       includeInAutoRefresh: document.getElementById('cfgAutoRefresh' + j)?.checked ?? cfgData.profiles[j].includeInAutoRefresh,
+      autoRefreshCurrentMonth: document.getElementById('cfgAutoRefreshCurrentMonth' + j)?.checked ?? true,
       slackWebhookUrl: document.getElementById('cfgSlackWebhook' + j)?.value || null,
       teamsWebhookUrl: document.getElementById('cfgTeamsWebhook' + j)?.value || null,
       notificationEmail: document.getElementById('cfgNotifEmail' + j)?.value || null,
@@ -1646,6 +1652,7 @@ async function saveConfigEditor() {
       certPasswordEnv: authMethod === 'certificate' ? (document.getElementById('cfgCertPassEnv' + i)?.value || null) : null,
       certPasswordFile: authMethod === 'certificate' ? (document.getElementById('cfgCertPassFile' + i)?.value || null) : null,
       includeInAutoRefresh: document.getElementById('cfgAutoRefresh' + i)?.checked || false,
+      autoRefreshCurrentMonth: document.getElementById('cfgAutoRefreshCurrentMonth' + i)?.checked ?? true,
       slackWebhookUrl: document.getElementById('cfgSlackWebhook' + i)?.value || null,
       teamsWebhookUrl: document.getElementById('cfgTeamsWebhook' + i)?.value || null,
       notificationEmail: document.getElementById('cfgNotifEmail' + i)?.value || null,


### PR DESCRIPTION
Introduces configurable date range behavior for auto-refresh operations

Adds checkbox to limit auto-refresh to current month by default
Updates SMTP configuration UI with protocol selection and test button
Enhances extended notifications with detailed invoice information
Removes redundant notification format examples from documentation

Improves user control over automated invoice detection scope
Prevents missed invoices when crossing month boundaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile "Auto-refresh date range" option to limit auto-refresh to the current month.
  * Per-profile "Extended notifications" toggle to include invoice details (date, NIP, company name) in notifications.
  * "Send test" button added to the Email configuration to verify SMTP settings.

* **Documentation**
  * Updated documentation and SMTP wording/labels for protocol, port, and From-address behavior.
  * Removed explicit per-detection example message from notification docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->