### PR TITLE
fix: improves token handling and refresh timing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,10 @@ LABEL org.opencontainers.image.licenses="GPL-3.0"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
-# Create cache and output directories (config dir managed by named volume)
-RUN mkdir -p /root/.cache/ksefcli /data
+# Pre-create data directories. Both config and cache dirs are overridden by
+# named volumes in docker-compose, but creating them here ensures the image
+# works standalone (docker run without -v) with correct ownership.
+RUN mkdir -p /root/.config/ksefcli /root/.cache/ksefcli /data
 
 WORKDIR /output
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Przy pierwszym uruchomieniu bez pliku konfiguracyjnego GUI otwiera **kreator kon
 |     4     | `<katalog-exe>/ksefcli.yaml`                  |
 |     5     | `~/.config/ksefcli/ksefcli.yaml` _(domyślne)_ |
 
+#### Lokalizacje plików (Linux/macOS)
+
+| Plik                                   | Opis                      |
+| -------------------------------------- | ------------------------- |
+| `~/.config/ksefcli/ksefcli.yaml`       | Konfiguracja profili      |
+| `~/.config/ksefcli/gui-prefs.json`     | Preferencje GUI           |
+| `~/.cache/ksefcli/ksefcli.json`        | Tokeny sesji              |
+| `~/.cache/ksefcli/db/invoice-cache.db` | Cache faktur (SQLite)     |
+| `~/.cache/ksefcli/*.log`               | Logi                      |
+
 ```yaml
 active_profile: firma1
 
@@ -390,6 +400,16 @@ On first launch without a config file the GUI opens the **setup wizard** automat
 |    3     | `./ksefcli.yaml` — current directory         |
 |    4     | `<exe-dir>/ksefcli.yaml`                     |
 |    5     | `~/.config/ksefcli/ksefcli.yaml` _(default)_ |
+
+#### Data file locations (Linux/macOS)
+
+| File                                   | Description                 |
+| -------------------------------------- | --------------------------- |
+| `~/.config/ksefcli/ksefcli.yaml`       | Profile configuration       |
+| `~/.config/ksefcli/gui-prefs.json`     | GUI preferences             |
+| `~/.cache/ksefcli/ksefcli.json`        | Session tokens              |
+| `~/.cache/ksefcli/db/invoice-cache.db` | Invoice cache (SQLite)      |
+| `~/.cache/ksefcli/*.log`               | Logs                        |
 
 ```yaml
 active_profile: company1

--- a/README.md
+++ b/README.md
@@ -269,13 +269,13 @@ Sieć lokalna (LAN)  :80 / :443
 <details>
 <summary><b>Woluminy</b></summary>
 
-| Ścieżka               | Typ          | Opis                              |
-| --------------------- | ------------ | --------------------------------- |
-| `ksefcli-output`      | named volume | Pobrane faktury (`/data`)         |
-| `ksefcli-config`      | named volume | `ksefcli.yaml`                    |
-| `ksefcli-cache`       | named volume | Tokeny, preferencje, cache SQLite |
-| `traefik-acme`        | named volume | Certyfikaty TLS Let's Encrypt     |
-| `./ofelia/config.ini` | bind (ro)    | Harmonogram Ofelia                |
+| Ścieżka               | Typ          | Opis                                                                    |
+| --------------------- | ------------ | ----------------------------------------------------------------------- |
+| `ksefcli-output`      | named volume | Pobrane faktury (`/data`)                                               |
+| `ksefcli-config`      | named volume | `ksefcli.yaml` + preferencje GUI (`gui-prefs.json`) w `~/.config/ksefcli` |
+| `ksefcli-cache`       | named volume | Tokeny sesji, cache SQLite, logi w `~/.cache/ksefcli`                  |
+| `traefik-acme`        | named volume | Certyfikaty TLS Let's Encrypt                                           |
+| `./ofelia/config.ini` | bind (ro)    | Harmonogram Ofelia                                                      |
 
 </details>
 
@@ -545,13 +545,13 @@ Local network (LAN)  :80 / :443
 <details>
 <summary><b>Volumes</b></summary>
 
-| Path                  | Type         | Description                             |
-| --------------------- | ------------ | --------------------------------------- |
-| `ksefcli-output`      | named volume | Downloaded invoices (`/data`)           |
-| `ksefcli-config`      | named volume | `ksefcli.yaml`                          |
-| `ksefcli-cache`       | named volume | Session tokens, GUI prefs, SQLite cache |
-| `traefik-acme`        | named volume | Let's Encrypt TLS certificates          |
-| `./ofelia/config.ini` | bind (ro)    | Ofelia scheduler configuration          |
+| Path                  | Type         | Description                                                                  |
+| --------------------- | ------------ | ---------------------------------------------------------------------------- |
+| `ksefcli-output`      | named volume | Downloaded invoices (`/data`)                                                |
+| `ksefcli-config`      | named volume | `ksefcli.yaml` + GUI preferences (`gui-prefs.json`) in `~/.config/ksefcli`  |
+| `ksefcli-cache`       | named volume | Session tokens, SQLite cache, logs in `~/.cache/ksefcli`                    |
+| `traefik-acme`        | named volume | Let's Encrypt TLS certificates                                               |
+| `./ofelia/config.ini` | bind (ro)    | Ofelia scheduler configuration                                               |
 
 </details>
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -912,7 +912,7 @@ public class GuiCommand : IWithConfigCommand
 
             GuiPrefs prefs = LoadPrefs();
             int minutes = prefs.AutoRefreshMinutes ?? 0;
-            if (minutes < 1)
+            if (minutes < 10)
             {
                 continue;
             }
@@ -984,7 +984,26 @@ public class GuiCommand : IWithConfigCommand
         InvoiceQueryFilters filters = await BuildFiltersAsync(sp, ct).ConfigureAwait(false);
 
         IKSeFClient client = scope.ServiceProvider.GetRequiredService<IKSeFClient>();
-        List<InvoiceSummary> invoices = await FetchAllPagesAsync(client, filters, accessToken, ct, abortOn429: true).ConfigureAwait(false);
+        List<InvoiceSummary> invoices;
+        try
+        {
+            invoices = await FetchAllPagesAsync(client, filters, accessToken, ct, abortOn429: true).ConfigureAwait(false);
+            // Suggestion 1: invalidate the stored access token after every successful fetch.
+            // KSeF revokes access tokens as soon as the search session completes, so ValidUntil
+            // (~2 h) is misleading. Expiring it here ensures the next cycle does a TokenRefresh
+            // instead of reusing a server-revoked token and cascading into three 401s.
+            ExpireStoredAccessToken(name, profile);
+        }
+        catch (KsefApiException ex401) when (ex401.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            // Suggestion 2: server revoked the token mid-fetch — expire it and retry once.
+            Log.LogWarning($"[bg-refresh] '{name}': HTTP 401 mid-fetch — forcing token refresh and retrying once");
+            ExpireStoredAccessToken(name, profile);
+            // GetAccessTokenForProfile sees the expired access token and performs TokenRefresh.
+            string freshToken = await GetAccessTokenForProfile(name, profile, scope, ct).ConfigureAwait(false);
+            invoices = await FetchAllPagesAsync(client, filters, freshToken, ct, abortOn429: true).ConfigureAwait(false);
+            ExpireStoredAccessToken(name, profile);
+        }
 
         if (prev == null)
         {
@@ -1051,6 +1070,10 @@ public class GuiCommand : IWithConfigCommand
                     List<string> channelsOk = webhookTasks.Where(t => t.Task.IsCompletedSuccessfully && t.Task.Result).Select(t => t.Name).ToList();
                     List<string> channelsFailed = webhookTasks.Where(t => !t.Task.IsCompletedSuccessfully || !t.Task.Result).Select(t => t.Name).ToList();
                     _invoiceCache.UpdateNotifiedChannels(profileKey, toNotify.Select(i => i.KsefNumber), channelsOk, channelsFailed);
+                }
+                else
+                {
+                    Log.LogWarning($"[bg-refresh] Profile '{name}': {toNotify.Count} new invoice(s) detected but no notification channels configured (Slack, Teams, e-mail).");
                 }
             }
         }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -47,7 +47,9 @@ public class GuiCommand : IWithConfigCommand
     private Dictionary<string, string> _allProfiles = new(); // name → NIP
     private bool _setupRequired = false;
 
-    private static readonly string PrefsPath = Path.Combine(CacheDir, "gui-prefs.json");
+    private static readonly string PrefsPath = Path.Combine(ConfigDir, "gui-prefs.json");
+    // Legacy location used before preferences were moved from ~/.cache to ~/.config.
+    private static readonly string LegacyPrefsPath = Path.Combine(CacheDir, "gui-prefs.json");
     private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(10) };
 
     private const int DefaultLanPort = 18150;
@@ -111,6 +113,21 @@ public class GuiCommand : IWithConfigCommand
 
     private static GuiPrefs LoadPrefs()
     {
+        // One-time migration: move gui-prefs.json from the old cache location to ~/.config.
+        if (!File.Exists(PrefsPath) && File.Exists(LegacyPrefsPath))
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(PrefsPath)!);
+                File.Move(LegacyPrefsPath, PrefsPath);
+                Log.LogInformation($"[prefs] Migrated gui-prefs.json from {LegacyPrefsPath} to {PrefsPath}");
+            }
+            catch (Exception ex)
+            {
+                Log.LogWarning($"[prefs] Migration failed: {ex.Message}");
+            }
+        }
+
         try
         {
             if (File.Exists(PrefsPath))
@@ -120,7 +137,13 @@ public class GuiCommand : IWithConfigCommand
                     ?? new GuiPrefs();
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            // Log instead of silently swallowing: a JsonException here (e.g. from a partially
+            // written file) would cause every subsequent SavePrefs call to use an empty GuiPrefs
+            // as the base, wiping SMTP credentials and webhook URLs from disk.
+            Log.LogWarning($"[prefs] Failed to load {PrefsPath}: {ex.GetType().Name}: {ex.Message}. Using defaults.");
+        }
         return new GuiPrefs();
     }
 
@@ -129,9 +152,17 @@ public class GuiCommand : IWithConfigCommand
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(PrefsPath)!);
-            File.WriteAllText(PrefsPath, JsonSerializer.Serialize(prefs));
+            // Write atomically: write to a temp file first, then rename.
+            // File.WriteAllText is not atomic — a crash mid-write leaves a corrupt JSON file
+            // that permanently breaks LoadPrefs (silent catch → empty GuiPrefs → data loss).
+            string tempPath = PrefsPath + ".tmp";
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(prefs));
+            File.Move(tempPath, PrefsPath, overwrite: true);
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[prefs] Failed to save {PrefsPath}: {ex.Message}");
+        }
     }
 
     public override async Task<int> ExecuteAsync(CancellationToken cancellationToken)

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -156,7 +156,7 @@ public class GuiCommand : IWithConfigCommand
         // Try PrefsPath first, then fall back to LegacyPrefsPath (still present when copy failed).
         // Log and continue to the next candidate on any read/parse failure; return defaults only
         // if both are unavailable or unparseable.
-        foreach (string candidate in (string[])[PrefsPath, LegacyPrefsPath])
+        foreach (string candidate in new[] { PrefsPath, LegacyPrefsPath })
         {
             try
             {
@@ -186,15 +186,18 @@ public class GuiCommand : IWithConfigCommand
 
     private static void SavePrefs(GuiPrefs prefs)
     {
+        // Unique suffix per invocation avoids collisions when saves run concurrently.
+        string tempPath = Path.Join(Path.GetDirectoryName(PrefsPath)!, $".gui-prefs-{Guid.NewGuid():N}.tmp");
+        bool committed = false;
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(PrefsPath)!);
-            // Write atomically: write to a temp file first, then rename.
+            // Write atomically: write to a unique temp file first, then rename.
             // File.WriteAllText is not atomic — a crash mid-write leaves a corrupt JSON file
             // that permanently breaks LoadPrefs (silent catch → empty GuiPrefs → data loss).
-            string tempPath = PrefsPath + ".tmp";
             File.WriteAllText(tempPath, JsonSerializer.Serialize(prefs));
             File.Move(tempPath, PrefsPath, overwrite: true);
+            committed = true;
         }
         catch (IOException ex)
         {
@@ -207,6 +210,16 @@ public class GuiCommand : IWithConfigCommand
         catch (JsonException ex)
         {
             Log.LogWarning($"[prefs] Failed to save {PrefsPath}: {ex.Message}");
+        }
+        finally
+        {
+            if (!committed)
+            {
+                // Best-effort cleanup; File.Delete does not throw if file does not exist.
+                try { File.Delete(tempPath); }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
         }
     }
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -226,12 +226,6 @@ public class GuiCommand : IWithConfigCommand
                     // Log permission issues so repeated cleanup failures are visible for diagnostics.
                     Log.LogWarning($"[prefs] Failed to delete temporary prefs file '{tempPath}': {ex.Message}");
                 }
-                    Log.LogDebug($"[prefs] Failed to delete temp prefs file '{tempPath}': {ex.Message}");
-                }
-                catch (UnauthorizedAccessException ex)
-                {
-                    Log.LogDebug($"[prefs] Failed to delete temp prefs file '{tempPath}': {ex.Message}");
-                }
             }
         }
     }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -47,9 +47,9 @@ public class GuiCommand : IWithConfigCommand
     private Dictionary<string, string> _allProfiles = new(); // name → NIP
     private bool _setupRequired = false;
 
-    private static readonly string PrefsPath = Path.Combine(ConfigDir, "gui-prefs.json");
+    private static readonly string PrefsPath = Path.Join(ConfigDir, "gui-prefs.json");
     // Legacy location used before preferences were moved from ~/.cache to ~/.config.
-    private static readonly string LegacyPrefsPath = Path.Combine(CacheDir, "gui-prefs.json");
+    private static readonly string LegacyPrefsPath = Path.Join(CacheDir, "gui-prefs.json");
     private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromSeconds(10) };
 
     private const int DefaultLanPort = 18150;
@@ -116,33 +116,70 @@ public class GuiCommand : IWithConfigCommand
         // One-time migration: move gui-prefs.json from the old cache location to ~/.config.
         if (!File.Exists(PrefsPath) && File.Exists(LegacyPrefsPath))
         {
+            bool moved = false;
             try
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(PrefsPath)!);
                 File.Move(LegacyPrefsPath, PrefsPath);
                 Log.LogInformation($"[prefs] Migrated gui-prefs.json from {LegacyPrefsPath} to {PrefsPath}");
+                moved = true;
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
-                Log.LogWarning($"[prefs] Migration failed: {ex.Message}");
+                Log.LogWarning($"[prefs] File.Move migration failed ({ex.GetType().Name}: {ex.Message}); trying non-destructive copy.");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Log.LogWarning($"[prefs] File.Move migration failed ({ex.GetType().Name}: {ex.Message}); trying non-destructive copy.");
+            }
+
+            if (!moved)
+            {
+                // Non-destructive fallback: copy without removing the legacy file.
+                // If this also fails, the read loop below will still find and parse LegacyPrefsPath.
+                try
+                {
+                    File.Copy(LegacyPrefsPath, PrefsPath, overwrite: false);
+                    Log.LogInformation($"[prefs] Copied gui-prefs.json to {PrefsPath} (legacy file preserved at {LegacyPrefsPath})");
+                }
+                catch (IOException ex)
+                {
+                    Log.LogWarning($"[prefs] File.Copy also failed ({ex.GetType().Name}: {ex.Message}); will read legacy prefs directly.");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    Log.LogWarning($"[prefs] File.Copy also failed ({ex.GetType().Name}: {ex.Message}); will read legacy prefs directly.");
+                }
             }
         }
 
-        try
+        // Try PrefsPath first, then fall back to LegacyPrefsPath (still present when copy failed).
+        // Log and continue to the next candidate on any read/parse failure; return defaults only
+        // if both are unavailable or unparseable.
+        foreach (string candidate in (string[])[PrefsPath, LegacyPrefsPath])
         {
-            if (File.Exists(PrefsPath))
+            try
             {
-                string json = File.ReadAllText(PrefsPath);
+                if (!File.Exists(candidate)) { continue; }
+                string json = File.ReadAllText(candidate);
+                // Log instead of silently swallowing: a JsonException here (e.g. from a partially
+                // written file) would cause every subsequent SavePrefs call to use an empty GuiPrefs
+                // as the base, wiping SMTP credentials and webhook URLs from disk.
                 return JsonSerializer.Deserialize<GuiPrefs>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                     ?? new GuiPrefs();
             }
-        }
-        catch (Exception ex)
-        {
-            // Log instead of silently swallowing: a JsonException here (e.g. from a partially
-            // written file) would cause every subsequent SavePrefs call to use an empty GuiPrefs
-            // as the base, wiping SMTP credentials and webhook URLs from disk.
-            Log.LogWarning($"[prefs] Failed to load {PrefsPath}: {ex.GetType().Name}: {ex.Message}. Using defaults.");
+            catch (IOException ex)
+            {
+                Log.LogWarning($"[prefs] Failed to load {candidate}: {ex.GetType().Name}: {ex.Message}.");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Log.LogWarning($"[prefs] Failed to load {candidate}: {ex.GetType().Name}: {ex.Message}.");
+            }
+            catch (JsonException ex)
+            {
+                Log.LogWarning($"[prefs] Failed to parse {candidate}: {ex.GetType().Name}: {ex.Message}.");
+            }
         }
         return new GuiPrefs();
     }
@@ -159,7 +196,15 @@ public class GuiCommand : IWithConfigCommand
             File.WriteAllText(tempPath, JsonSerializer.Serialize(prefs));
             File.Move(tempPath, PrefsPath, overwrite: true);
         }
-        catch (Exception ex)
+        catch (IOException ex)
+        {
+            Log.LogWarning($"[prefs] Failed to save {PrefsPath}: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.LogWarning($"[prefs] Failed to save {PrefsPath}: {ex.Message}");
+        }
+        catch (JsonException ex)
         {
             Log.LogWarning($"[prefs] Failed to save {PrefsPath}: {ex.Message}");
         }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -217,8 +217,14 @@ public class GuiCommand : IWithConfigCommand
             {
                 // Best-effort cleanup; File.Delete does not throw if file does not exist.
                 try { File.Delete(tempPath); }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
+                catch (IOException ex)
+                {
+                    Log.LogDebug($"[prefs] Failed to delete temp prefs file '{tempPath}': {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    Log.LogDebug($"[prefs] Failed to delete temp prefs file '{tempPath}': {ex.Message}");
+                }
             }
         }
     }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -217,8 +217,15 @@ public class GuiCommand : IWithConfigCommand
             {
                 // Best-effort cleanup; File.Delete does not throw if file does not exist.
                 try { File.Delete(tempPath); }
-                catch (IOException ex)
+                catch (IOException)
                 {
+                    // Swallow I/O errors during best-effort cleanup; main failure is already logged.
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    // Log permission issues so repeated cleanup failures are visible for diagnostics.
+                    Log.LogWarning($"[prefs] Failed to delete temporary prefs file '{tempPath}': {ex.Message}");
+                }
                     Log.LogDebug($"[prefs] Failed to delete temp prefs file '{tempPath}': {ex.Message}");
                 }
                 catch (UnauthorizedAccessException ex)

--- a/src/KSeFCli/IGlobalCommand.cs
+++ b/src/KSeFCli/IGlobalCommand.cs
@@ -5,6 +5,7 @@ namespace KSeFCli;
 public abstract class IGlobalCommand
 {
     public static readonly string CacheDir = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".cache", "ksefcli");
+    public static readonly string ConfigDir = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".config", "ksefcli");
 
     [Option('v', "verbose", HelpText = "Enable verbose logging")]
     public bool Verbose { get; set; }

--- a/src/KSeFCli/IGlobalCommand.cs
+++ b/src/KSeFCli/IGlobalCommand.cs
@@ -4,8 +4,8 @@ namespace KSeFCli;
 
 public abstract class IGlobalCommand
 {
-    public static readonly string CacheDir = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".cache", "ksefcli");
-    public static readonly string ConfigDir = System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".config", "ksefcli");
+    public static readonly string CacheDir = System.IO.Path.Join(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".cache", "ksefcli");
+    public static readonly string ConfigDir = System.IO.Path.Join(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile), ".config", "ksefcli");
 
     [Option('v', "verbose", HelpText = "Enable verbose logging")]
     public bool Verbose { get; set; }

--- a/src/KSeFCli/IWithConfigCommand.cs
+++ b/src/KSeFCli/IWithConfigCommand.cs
@@ -428,20 +428,27 @@ public abstract class IWithConfigCommand : IGlobalCommand
     /// </summary>
     protected internal void ExpireStoredAccessToken(string profileName, ProfileConfig profile)
     {
-        TokenStore tokenStore = GetTokenStore();
-        TokenStore.Key key = new TokenStore.Key(profileName, profile);
-        TokenStore.Data? stored = tokenStore.GetToken(key);
-        if (stored == null)
+        try
         {
-            return;
-        }
+            TokenStore tokenStore = GetTokenStore();
+            TokenStore.Key key = new TokenStore.Key(profileName, profile);
+            TokenStore.Data? stored = tokenStore.GetToken(key);
+            if (stored == null)
+            {
+                return;
+            }
 
-        tokenStore.SetToken(key, new TokenStore.Data(new AuthenticationOperationStatusResponse
+            tokenStore.SetToken(key, new TokenStore.Data(new AuthenticationOperationStatusResponse
+            {
+                AccessToken = new TokenInfo { Token = string.Empty, ValidUntil = DateTime.MinValue },
+                RefreshToken = stored.Response.RefreshToken,
+            }));
+            Log.LogDebug($"[bg-refresh] '{profileName}': access token invalidated (KSeF revokes after search session)");
+        }
+        catch (IOException ex)
         {
-            AccessToken = new TokenInfo { Token = string.Empty, ValidUntil = DateTime.MinValue },
-            RefreshToken = stored.Response.RefreshToken,
-        }));
-        Log.LogDebug($"[bg-refresh] '{profileName}': access token invalidated (KSeF revokes after search session)");
+            Log.LogWarning($"[bg-refresh] '{profileName}': failed to expire stored access token — {ex.Message}");
+        }
     }
 
     public async Task<ICryptographyService> GetCryptographicService(IServiceScope scope, CancellationToken cancellationToken)

--- a/src/KSeFCli/IWithConfigCommand.cs
+++ b/src/KSeFCli/IWithConfigCommand.cs
@@ -418,6 +418,32 @@ public abstract class IWithConfigCommand : IGlobalCommand
         return authResponse.AccessToken.Token;
     }
 
+    /// <summary>
+    /// Overwrites the stored access token for the given profile with an already-expired sentinel
+    /// so the next call to <see cref="GetAccessTokenForProfile"/> is forced to perform a
+    /// <see cref="TokenRefresh"/> instead of reusing a server-revoked token.
+    /// KSeF revokes access tokens as soon as a search session completes, regardless of the
+    /// <c>ValidUntil</c> timestamp reported at login (~2 hours). Calling this after every
+    /// successful fetch prevents three consecutive 401 cycles at the start of each bg-refresh.
+    /// </summary>
+    protected internal void ExpireStoredAccessToken(string profileName, ProfileConfig profile)
+    {
+        TokenStore tokenStore = GetTokenStore();
+        TokenStore.Key key = new TokenStore.Key(profileName, profile);
+        TokenStore.Data? stored = tokenStore.GetToken(key);
+        if (stored == null)
+        {
+            return;
+        }
+
+        tokenStore.SetToken(key, new TokenStore.Data(new AuthenticationOperationStatusResponse
+        {
+            AccessToken = new TokenInfo { Token = string.Empty, ValidUntil = DateTime.MinValue },
+            RefreshToken = stored.Response.RefreshToken,
+        }));
+        Log.LogDebug($"[bg-refresh] '{profileName}': access token invalidated (KSeF revokes after search session)");
+    }
+
     public async Task<ICryptographyService> GetCryptographicService(IServiceScope scope, CancellationToken cancellationToken)
     {
         ICryptographyService cryptographyService = scope.ServiceProvider.GetRequiredService<ICryptographyService>();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1332,9 +1332,10 @@ async function savePrefs() {
     smtpFrom: $('smtpFrom').value || null
   };
   const mins = prefs.autoRefreshMinutes;
-  // Values 1–9 are below the server minimum of 10 — normalise to 0 (disabled) so the timer
-  // and notification-permission request are consistent with what the server will ignore.
+  // Values 1–9 are below the server minimum of 10 — normalise to 0 (disabled) so the timer,
+  // notification-permission request, and the persisted value are all consistent.
   const effectiveMins = (mins > 0 && mins < 10) ? 0 : mins;
+  prefs.autoRefreshMinutes = effectiveMins;
   const resp = await fetch('/prefs', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prefs) });
   if (!resp.ok) throw new Error('HTTP ' + resp.status);
   const data = await resp.json();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1332,13 +1332,16 @@ async function savePrefs() {
     smtpFrom: $('smtpFrom').value || null
   };
   const mins = prefs.autoRefreshMinutes;
+  // Values 1–9 are below the server minimum of 10 — normalise to 0 (disabled) so the timer
+  // and notification-permission request are consistent with what the server will ignore.
+  const effectiveMins = (mins > 0 && mins < 10) ? 0 : mins;
   const resp = await fetch('/prefs', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prefs) });
   if (!resp.ok) throw new Error('HTTP ' + resp.status);
   const data = await resp.json();
   if (data?.error) throw new Error(data.error);
   // Only mutate runtime state after the save is confirmed on disk
-  startAutoRefresh(mins);
-  if (mins > 0) requestNotificationPermission();
+  startAutoRefresh(effectiveMins);
+  if (effectiveMins > 0) requestNotificationPermission();
 }
 
 async function onProfileChange() {
@@ -2053,7 +2056,8 @@ async function doSearch() {
 
 function startAutoRefresh(minutes) {
   if (autoRefreshTimer) { clearInterval(autoRefreshTimer); autoRefreshTimer = null; }
-  if (!minutes || minutes < 1) return;
+  // Values 1–9 are below the server-enforced minimum of 10 minutes; treat them as disabled.
+  if (!minutes || minutes < 10) return;
   autoRefreshTimer = setInterval(() => { if (lastSearchParams) silentRefresh(); }, minutes * 60 * 1000);
 }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -918,8 +918,8 @@ body.dark .pref-label{color:#aaa}
           <div style="display:flex;align-items:center;gap:.5rem">
             <input id="autoRefreshMinutes" type="number" value="0" min="0" max="1440" step="1"
                    style="width:5rem"
-                   title="0 = wyłączone, 1–1440 minut">
-            <span style="font-size:.75rem;color:#999">0 = wyłączone</span>
+                   title="0 = wyłączone, min. 10 minut">
+            <span style="font-size:.75rem;color:#999">0 = wyłączone, min. 10</span>
           </div>
         </div>
         <div class="pref-row">


### PR DESCRIPTION
Fixes authentication issues by properly managing token lifecycle

- Increases minimum auto-refresh interval from 1 to 10 minutes
- Adds automatic token expiration after successful API calls
- Implements retry logic for mid-fetch authentication failures
- Adds warning for profiles without notification channels configured
- Prevents cascading authentication errors in background refresh cycles

Server revokes tokens immediately after search sessions despite longer validity timestamps, causing unnecessary 401 error cycles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust preference migration/load/save with atomic writes, safer fallbacks and clearer error logging.
  * Background refresh hardened: tokens are expired promptly, 401 triggers a single refresh+retry cycle, and revoked tokens aren’t reused.
  * Emit a warning when new invoices arrive but no notification channels are configured.

* **Changes**
  * Minimum auto-refresh raised to 10 minutes; values below 10 are normalized to disabled.
  * Notification permission requested only when auto-refresh is effectively enabled.

* **Documentation**
  * README and container notes updated to document GUI prefs and new config locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->