### PR TITLE
feat: adds retry mechanism for failed notifications

### DIFF
--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -421,14 +421,19 @@ public class GuiCommand : IWithConfigCommand
                 SmtpHost: root.TryGetProperty("smtpHost", out JsonElement smh) ? smh.GetString() : null,
                 SmtpPort: root.TryGetProperty("smtpPort", out JsonElement smpo) && smpo.TryGetInt32(out int smpoVal) ? smpoVal : (int?)null,
                 SmtpSecurity: root.TryGetProperty("smtpSecurity", out JsonElement smse) ? smse.GetString() : null,
-                SmtpUser: root.TryGetProperty("smtpUser", out JsonElement smui) ? smui.GetString() : null,
-                // Preserve existing password if JS sends null/empty (password field may be blank when re-opening prefs).
+                SmtpUser: root.TryGetProperty("smtpUser", out JsonElement smui)
+                    ? smui.GetString()
+                    : null,
+                // Preserve existing password if JS sends null/empty
+                // (password field may be blank when re-opening prefs).
                 SmtpPassword: root.TryGetProperty("smtpPassword", out JsonElement smpw)
                     && smpw.ValueKind != JsonValueKind.Null
                     && !string.IsNullOrEmpty(smpw.GetString())
                     ? smpw.GetString()
                     : existingPrefs.SmtpPassword,
-                SmtpFrom: root.TryGetProperty("smtpFrom", out JsonElement smfr) ? smfr.GetString() : null,
+                SmtpFrom: root.TryGetProperty("smtpFrom", out JsonElement smfr)
+                    ? smfr.GetString()
+                    : null,
                 // Preserve ProfilePrefs from disk — JS savePrefs() never sends it,
                 // so this prevents webhook URLs from being wiped on every prefs save.
                 ProfilePrefs: existingPrefs.ProfilePrefs);
@@ -813,7 +818,7 @@ public class GuiCommand : IWithConfigCommand
         {
             KsefCliConfig statusConfig;
             try { statusConfig = CurrentConfig; }
-            catch { return Task.FromResult<object>(new { }); }
+            catch (Exception) { return Task.FromResult<object>(new { }); }
             Dictionary<string, object> result = [];
             foreach ((string profName, ProfileConfig profCfg) in statusConfig.Profiles)
             {
@@ -1285,7 +1290,14 @@ public class GuiCommand : IWithConfigCommand
 
         if (retryTasks.Count == 0) { return; }
 
-        await Task.WhenAll(retryTasks.Select(t => (Task)t.Task)).ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(retryTasks.Select(t => (Task)t.Task)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[bg-retry] '{name}' one or more retry tasks faulted: {ex.Message}");
+        }
         HashSet<string> succeeded = retryTasks
             .Where(t => t.Task.IsCompletedSuccessfully && t.Task.Result)
             .Select(t => t.Channel).ToHashSet();
@@ -1307,7 +1319,9 @@ public class GuiCommand : IWithConfigCommand
             List<string> remaining = retry.ChannelsFailed
                 .Where(ch => stillFailed.Contains(ch) || !dispatched.Contains(ch))
                 .ToList();
-            _invoiceCache.UpdateRetryOutcome(profileKey, [retry.KsefNumber], nowOk, remaining, retry.RetryCount + 1);
+            bool anyAttempted = retry.ChannelsFailed.Any(dispatched.Contains);
+            int newRetryCount = anyAttempted ? retry.RetryCount + 1 : retry.RetryCount;
+            _invoiceCache.UpdateRetryOutcome(profileKey, [retry.KsefNumber], nowOk, remaining, newRetryCount);
         }
 
         if (_server != null)

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -818,7 +818,7 @@ public class GuiCommand : IWithConfigCommand
         {
             KsefCliConfig statusConfig;
             try { statusConfig = CurrentConfig; }
-            catch (Exception) { return Task.FromResult<object>(new { }); }
+            catch (InvalidOperationException) { return Task.FromResult<object>(new { }); }
             Dictionary<string, object> result = [];
             foreach ((string profName, ProfileConfig profCfg) in statusConfig.Profiles)
             {
@@ -1244,6 +1244,10 @@ public class GuiCommand : IWithConfigCommand
         string? slackUrl = profilePrefs?.SlackWebhookUrl;
         string? teamsUrl = profilePrefs?.TeamsWebhookUrl;
         string? emailTo = profilePrefs?.NotificationEmail;
+        string slackHost = Uri.TryCreate(slackUrl, UriKind.Absolute, out Uri? slackUri)
+            ? slackUri.Host : slackUrl ?? "";
+        string teamsHost = Uri.TryCreate(teamsUrl, UriKind.Absolute, out Uri? teamsUri)
+            ? teamsUri.Host : teamsUrl ?? "";
 
         // Build per-channel invoice lists from the current cache
         Dictionary<string, List<InvoiceSummary>> retryInvoicesByChannel = [];
@@ -1271,11 +1275,11 @@ public class GuiCommand : IWithConfigCommand
             switch (ch)
             {
                 case "Slack" when !string.IsNullOrEmpty(slackUrl):
-                    Log.LogInformation($"[bg-retry] '{name}' Slack: retrying {chInvoices.Count} invoice(s) (host={new Uri(slackUrl).Host})");
+                    Log.LogInformation($"[bg-retry] '{name}' Slack: retrying {chInvoices.Count} invoice(s) (host={slackHost})");
                     retryTasks.Add(("Slack", SendSlackNotificationAsync(slackUrl, name, chInvoices, extended, ct)));
                     break;
                 case "Teams" when !string.IsNullOrEmpty(teamsUrl):
-                    Log.LogInformation($"[bg-retry] '{name}' Teams: retrying {chInvoices.Count} invoice(s) (host={new Uri(teamsUrl).Host})");
+                    Log.LogInformation($"[bg-retry] '{name}' Teams: retrying {chInvoices.Count} invoice(s) (host={teamsHost})");
                     retryTasks.Add(("Teams", SendTeamsNotificationAsync(teamsUrl, name, chInvoices, extended, ct)));
                     break;
                 case "Email" when !string.IsNullOrEmpty(emailTo):
@@ -1290,14 +1294,8 @@ public class GuiCommand : IWithConfigCommand
 
         if (retryTasks.Count == 0) { return; }
 
-        try
-        {
-            await Task.WhenAll(retryTasks.Select(t => (Task)t.Task)).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            Log.LogWarning($"[bg-retry] '{name}' one or more retry tasks faulted: {ex.Message}");
-        }
+        await Task.WhenAll(retryTasks.Select(t => (Task)t.Task))
+            .ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
         HashSet<string> succeeded = retryTasks
             .Where(t => t.Task.IsCompletedSuccessfully && t.Task.Result)
             .Select(t => t.Channel).ToHashSet();
@@ -1390,7 +1388,8 @@ public class GuiCommand : IWithConfigCommand
 
         string json = JsonSerializer.Serialize(payload);
         using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
-        string webhookHost = new Uri(webhookUrl).Host;
+        string webhookHost = Uri.TryCreate(webhookUrl, UriKind.Absolute, out Uri? swUri)
+            ? swUri.Host : webhookUrl;
         Log.LogDebug($"[slack-notify] POST to '{webhookHost}' for profile '{profileName}': {count} invoice(s)");
         try
         {
@@ -1479,7 +1478,8 @@ public class GuiCommand : IWithConfigCommand
 
         string json = JsonSerializer.Serialize(payload);
         using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
-        string webhookHost = new Uri(webhookUrl).Host;
+        string webhookHost = Uri.TryCreate(webhookUrl, UriKind.Absolute, out Uri? twUri)
+            ? twUri.Host : webhookUrl;
         Log.LogDebug($"[teams-notify] POST to '{webhookHost}' for profile '{profileName}': {count} invoice(s)");
         try
         {

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -809,6 +809,28 @@ public class GuiCommand : IWithConfigCommand
             return $"Testowy e-mail wysłany do: {toEmail}";
         };
 
+        server.OnNotificationStatus = () =>
+        {
+            KsefCliConfig statusConfig;
+            try { statusConfig = CurrentConfig; }
+            catch { return Task.FromResult<object>(new { }); }
+            Dictionary<string, object> result = [];
+            foreach ((string profName, ProfileConfig profCfg) in statusConfig.Profiles)
+            {
+                string profKey = new TokenStore.Key(profName, profCfg).ToCacheKey();
+                InvoiceCache.NotificationStatus status = _invoiceCache.LoadNotificationStatus(profKey);
+                result[profName] = new
+                {
+                    lastSentAt = status.LastSentAt,
+                    pendingRetries = status.PendingRetries,
+                    channelsOk = status.LastChannelsOk,
+                    channelsFailed = status.LastChannelsFailed,
+                    hasErrors = status.PendingRetries > 0,
+                };
+            }
+            return Task.FromResult<object>(result);
+        };
+
         server.Start(cancellationToken);
         Log.LogInformation($"GUI running at {server.LocalUrl}");
         _ = Task.Run(() => RunBackgroundProfileRefreshAsync(cancellationToken), cancellationToken);
@@ -1126,6 +1148,9 @@ public class GuiCommand : IWithConfigCommand
             }).ConfigureAwait(false);
         }
 
+        // Retry previously failed notification channels before dispatching new notifications.
+        await DispatchPendingRetriesAsync(profileKey, invoices, name, profilePrefs, prefs, ct).ConfigureAwait(false);
+
         // Webhooks fire only for invoices that are both new (not in prev cache) and not yet
         // notified (not in notification_sent table). This prevents duplicate webhook calls
         // across refresh cycles and across app restarts.
@@ -1139,14 +1164,18 @@ public class GuiCommand : IWithConfigCommand
             if (toNotify.Count > 0)
             {
                 // Deliberate at-most-once ordering: mark as notified BEFORE sending webhooks.
-                // If a webhook call fails, the invoice is still marked and will not be retried.
-                // This avoids duplicate notifications on transient errors at the cost of
-                // potentially missing one delivery. Change order here if at-least-once is preferred.
+                // If a webhook call fails, the invoice is still marked and will not be retried
+                // immediately — instead DispatchPendingRetriesAsync will retry on the next cycle
+                // using exponential backoff (5, 10, 20 min, up to 3 attempts).
                 _invoiceCache.MarkAsNotified(profileKey, toNotify.Select(i => i.KsefNumber));
                 string? slackUrl = profilePrefs?.SlackWebhookUrl;
                 string? teamsUrl = profilePrefs?.TeamsWebhookUrl;
                 string? emailTo = profilePrefs?.NotificationEmail;
                 bool extended = profilePrefs?.ExtendedNotifications ?? false;
+                Log.LogDebug($"[bg-refresh] '{name}' channels: " +
+                    $"Slack={(!string.IsNullOrEmpty(slackUrl) ? "configured" : "none")} " +
+                    $"Teams={(!string.IsNullOrEmpty(teamsUrl) ? "configured" : "none")} " +
+                    $"Email={(!string.IsNullOrEmpty(emailTo) ? MaskEmail(emailTo) : "none")}");
                 List<(string Name, Task<bool> Task)> webhookTasks = [];
                 if (!string.IsNullOrEmpty(slackUrl))
                 {
@@ -1166,12 +1195,130 @@ public class GuiCommand : IWithConfigCommand
                     List<string> channelsOk = webhookTasks.Where(t => t.Task.IsCompletedSuccessfully && t.Task.Result).Select(t => t.Name).ToList();
                     List<string> channelsFailed = webhookTasks.Where(t => !t.Task.IsCompletedSuccessfully || !t.Task.Result).Select(t => t.Name).ToList();
                     _invoiceCache.UpdateNotifiedChannels(profileKey, toNotify.Select(i => i.KsefNumber), channelsOk, channelsFailed);
+                    if (channelsFailed.Count > 0)
+                    {
+                        Log.LogWarning($"[bg-refresh] '{name}': {channelsFailed.Count} channel(s) failed — [{string.Join(", ", channelsFailed)}] — will retry in 5 min");
+                    }
+                    if (_server != null)
+                    {
+                        await _server.SendEventAsync("notification_outcome", new
+                        {
+                            profileName = name,
+                            invoiceCount = toNotify.Count,
+                            channelsOk,
+                            channelsFailed,
+                            pendingRetries = channelsFailed.Count,
+                        }).ConfigureAwait(false);
+                    }
                 }
                 else
                 {
                     Log.LogWarning($"[bg-refresh] Profile '{name}': {toNotify.Count} new invoice(s) detected but no notification channels configured (Slack, Teams, e-mail).");
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Retries delivery to channels that failed in a previous cycle. Matches pending ksef_numbers
+    /// against the current invoice cache, sends per-channel, then updates retry state with
+    /// exponential backoff (5→10→20 min, max 3 attempts total).
+    /// </summary>
+    private async Task DispatchPendingRetriesAsync(
+        string profileKey, List<InvoiceSummary> invoices,
+        string name, ProfilePrefs? profilePrefs, GuiPrefs prefs, CancellationToken ct)
+    {
+        List<InvoiceCache.PendingRetry> pending = _invoiceCache.LoadPendingRetries(profileKey);
+        if (pending.Count == 0) { return; }
+
+        IEnumerable<string> allFailedChannels = pending.SelectMany(p => p.ChannelsFailed).Distinct();
+        Log.LogInformation($"[bg-retry] '{name}': {pending.Count} invoice(s) with pending retries — channels: [{string.Join(", ", allFailedChannels)}]");
+
+        Dictionary<string, InvoiceSummary> invoiceMap = invoices.ToDictionary(i => i.KsefNumber);
+        bool extended = profilePrefs?.ExtendedNotifications ?? false;
+        string? slackUrl = profilePrefs?.SlackWebhookUrl;
+        string? teamsUrl = profilePrefs?.TeamsWebhookUrl;
+        string? emailTo = profilePrefs?.NotificationEmail;
+
+        // Build per-channel invoice lists from the current cache
+        Dictionary<string, List<InvoiceSummary>> retryInvoicesByChannel = [];
+        foreach (InvoiceCache.PendingRetry retry in pending)
+        {
+            foreach (string ch in retry.ChannelsFailed)
+            {
+                if (!retryInvoicesByChannel.ContainsKey(ch)) { retryInvoicesByChannel[ch] = []; }
+                if (invoiceMap.TryGetValue(retry.KsefNumber, out InvoiceSummary? inv))
+                {
+                    retryInvoicesByChannel[ch].Add(inv);
+                }
+            }
+        }
+
+        // Track which channels were actually dispatched (vs. skipped due to missing URL/data)
+        List<(string Channel, Task<bool> Task)> retryTasks = [];
+        foreach ((string ch, List<InvoiceSummary> chInvoices) in retryInvoicesByChannel)
+        {
+            if (chInvoices.Count == 0)
+            {
+                Log.LogWarning($"[bg-retry] '{name}' {ch}: {pending.Count(p => p.ChannelsFailed.Contains(ch))} pending invoice(s) no longer in cache — will retry next cycle");
+                continue;
+            }
+            switch (ch)
+            {
+                case "Slack" when !string.IsNullOrEmpty(slackUrl):
+                    Log.LogInformation($"[bg-retry] '{name}' Slack: retrying {chInvoices.Count} invoice(s) (host={new Uri(slackUrl).Host})");
+                    retryTasks.Add(("Slack", SendSlackNotificationAsync(slackUrl, name, chInvoices, extended, ct)));
+                    break;
+                case "Teams" when !string.IsNullOrEmpty(teamsUrl):
+                    Log.LogInformation($"[bg-retry] '{name}' Teams: retrying {chInvoices.Count} invoice(s) (host={new Uri(teamsUrl).Host})");
+                    retryTasks.Add(("Teams", SendTeamsNotificationAsync(teamsUrl, name, chInvoices, extended, ct)));
+                    break;
+                case "Email" when !string.IsNullOrEmpty(emailTo):
+                    Log.LogInformation($"[bg-retry] '{name}' Email: retrying {chInvoices.Count} invoice(s) to {MaskEmail(emailTo)}");
+                    retryTasks.Add(("Email", SendEmailNotificationAsync(emailTo, name, chInvoices, extended, prefs, ct)));
+                    break;
+                default:
+                    Log.LogWarning($"[bg-retry] '{name}' {ch}: has pending retries but channel URL is no longer configured");
+                    break;
+            }
+        }
+
+        if (retryTasks.Count == 0) { return; }
+
+        await Task.WhenAll(retryTasks.Select(t => (Task)t.Task)).ConfigureAwait(false);
+        HashSet<string> succeeded = retryTasks
+            .Where(t => t.Task.IsCompletedSuccessfully && t.Task.Result)
+            .Select(t => t.Channel).ToHashSet();
+        HashSet<string> stillFailed = retryTasks
+            .Where(t => !t.Task.IsCompletedSuccessfully || !t.Task.Result)
+            .Select(t => t.Channel).ToHashSet();
+        HashSet<string> dispatched = retryTasks.Select(t => t.Channel).ToHashSet();
+
+        Log.LogInformation($"[bg-retry] '{name}' outcomes: ok=[{string.Join(",", succeeded)}] still-failed=[{string.Join(",", stillFailed)}]");
+
+        foreach (InvoiceCache.PendingRetry retry in pending)
+        {
+            // Merge newly-succeeded channels into the ok list
+            List<string> nowOk = [
+                .. (retry.ChannelsOk?.Split(',').Where(s => !string.IsNullOrEmpty(s)) ?? []),
+                .. retry.ChannelsFailed.Where(succeeded.Contains),
+            ];
+            // Channels still failing + channels that were skipped (no data/URL) stay in failed
+            List<string> remaining = retry.ChannelsFailed
+                .Where(ch => stillFailed.Contains(ch) || !dispatched.Contains(ch))
+                .ToList();
+            _invoiceCache.UpdateRetryOutcome(profileKey, [retry.KsefNumber], nowOk, remaining, retry.RetryCount + 1);
+        }
+
+        if (_server != null)
+        {
+            await _server.SendEventAsync("notification_outcome", new
+            {
+                profileName = name,
+                isRetry = true,
+                channelsOk = succeeded.ToList(),
+                channelsFailed = stillFailed.ToList(),
+            }).ConfigureAwait(false);
         }
     }
 
@@ -1229,6 +1376,8 @@ public class GuiCommand : IWithConfigCommand
 
         string json = JsonSerializer.Serialize(payload);
         using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
+        string webhookHost = new Uri(webhookUrl).Host;
+        Log.LogDebug($"[slack-notify] POST to '{webhookHost}' for profile '{profileName}': {count} invoice(s)");
         try
         {
             using HttpResponseMessage resp = await _httpClient.PostAsync(webhookUrl, content, ct).ConfigureAwait(false);
@@ -1239,20 +1388,24 @@ public class GuiCommand : IWithConfigCommand
                 {
                     throw new HttpRequestException($"HTTP {(int)resp.StatusCode}: {body.Trim()}", null, resp.StatusCode);
                 }
-                Log.LogWarning($"[slack-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
+                Log.LogWarning($"[slack-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}' (host={webhookHost}): {body.Trim()}");
                 return false;
             }
+            Log.LogInformation($"[slack-notify] Delivered to '{webhookHost}' for profile '{profileName}': {count} invoice(s)");
             return true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (OperationCanceledException ex) when (!throwOnHttpError)
         {
-            Log.LogWarning($"[slack-notify] Timeout for profile '{profileName}': {ex.Message}");
+            Log.LogWarning($"[slack-notify] Timeout ({_httpClient.Timeout.TotalSeconds:F0}s) for profile '{profileName}' (host={webhookHost}): {ex.Message}");
             return false;
         }
         catch (HttpRequestException ex) when (!throwOnHttpError)
         {
-            Log.LogWarning($"[slack-notify] Failed for profile '{profileName}': {ex.Message}");
+            string netDetail = ex.InnerException is SocketException se
+                ? $"SocketError={se.SocketErrorCode} — {se.Message}"
+                : ex.Message;
+            Log.LogWarning($"[slack-notify] Network error for profile '{profileName}' (host={webhookHost}): {netDetail}");
             return false;
         }
     }
@@ -1312,6 +1465,8 @@ public class GuiCommand : IWithConfigCommand
 
         string json = JsonSerializer.Serialize(payload);
         using StringContent content = new StringContent(json, Encoding.UTF8, "application/json");
+        string webhookHost = new Uri(webhookUrl).Host;
+        Log.LogDebug($"[teams-notify] POST to '{webhookHost}' for profile '{profileName}': {count} invoice(s)");
         try
         {
             using HttpResponseMessage resp = await _httpClient.PostAsync(webhookUrl, content, ct).ConfigureAwait(false);
@@ -1322,20 +1477,24 @@ public class GuiCommand : IWithConfigCommand
                 {
                     throw new HttpRequestException($"HTTP {(int)resp.StatusCode}: {body.Trim()}", null, resp.StatusCode);
                 }
-                Log.LogWarning($"[teams-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}'");
+                Log.LogWarning($"[teams-notify] HTTP {(int)resp.StatusCode} for profile '{profileName}' (host={webhookHost}): {body.Trim()}");
                 return false;
             }
+            Log.LogInformation($"[teams-notify] Delivered to '{webhookHost}' for profile '{profileName}': {count} invoice(s)");
             return true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (OperationCanceledException ex) when (!throwOnHttpError)
         {
-            Log.LogWarning($"[teams-notify] Timeout for profile '{profileName}': {ex.Message}");
+            Log.LogWarning($"[teams-notify] Timeout ({_httpClient.Timeout.TotalSeconds:F0}s) for profile '{profileName}' (host={webhookHost}): {ex.Message}");
             return false;
         }
         catch (HttpRequestException ex) when (!throwOnHttpError)
         {
-            Log.LogWarning($"[teams-notify] Failed for profile '{profileName}': {ex.Message}");
+            string netDetail = ex.InnerException is SocketException se
+                ? $"SocketError={se.SocketErrorCode} — {se.Message}"
+                : ex.Message;
+            Log.LogWarning($"[teams-notify] Network error for profile '{profileName}' (host={webhookHost}): {netDetail}");
             return false;
         }
     }
@@ -1405,7 +1564,7 @@ public class GuiCommand : IWithConfigCommand
         {
             using TcpClient tcp = new TcpClient();
             await tcp.ConnectAsync(host, port, tcpCts.Token).ConfigureAwait(false);
-            Log.LogDebug($"[email-notify] Phase 1: TCP OK — proceeding to SMTP handshake");
+            Log.LogDebug($"[email-notify] Phase 1: TCP OK ({host}:{port}) — proceeding to SMTP handshake");
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested) { throw; }
         catch (OperationCanceledException)
@@ -1458,9 +1617,11 @@ public class GuiCommand : IWithConfigCommand
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            string msg = $"Błąd SMTP ({ex.GetType().Name}): {ex.Message}";
+            // Include inner exception detail (e.g. SmtpException status code, auth failure reason)
+            string inner = ex.InnerException is not null ? $" (inner: {ex.InnerException.GetType().Name}: {ex.InnerException.Message})" : "";
+            string msg = $"Błąd SMTP ({ex.GetType().Name}): {ex.Message}{inner}";
             if (throwOnError) { throw new InvalidOperationException(msg, ex); }
-            Log.LogWarning($"[email-notify] SMTP error for profile '{profileName}': {ex.Message}");
+            Log.LogWarning($"[email-notify] SMTP error for profile '{profileName}' ({host}:{port}): {ex.GetType().Name}: {ex.Message}{inner}");
             return false;
         }
     }

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -354,7 +354,7 @@ internal sealed class InvoiceCache
             string? channelsOk = reader.IsDBNull(1) ? null : reader.GetString(1);
             string channelsFailed = reader.GetString(2);
             int retryCount = reader.GetInt32(3);
-            List<string> failedList = [.. channelsFailed.Split(',').Where(s => !string.IsNullOrEmpty(s))];
+            IReadOnlyList<string> failedList = [.. channelsFailed.Split(',').Where(s => !string.IsNullOrEmpty(s))];
             result.Add(new PendingRetry(ksefNumber, channelsOk, failedList, retryCount));
         }
         if (result.Count > 0)
@@ -474,7 +474,7 @@ internal sealed class InvoiceCache
     public record PendingRetry(
         string KsefNumber,
         string? ChannelsOk,
-        List<string> ChannelsFailed,
+        IReadOnlyList<string> ChannelsFailed,
         int RetryCount);
 
     /// <summary>Snapshot of the most recent notification state for a profile, used by the UI status badge.</summary>

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -65,10 +65,16 @@ internal sealed class InvoiceCache
             """;
         notifCmd.ExecuteNonQuery();
 
-        // Schema migration: add channel columns to pre-existing databases.
+        // Schema migration: add columns to pre-existing databases.
         // Pre-check via PRAGMA so we only run ALTER when the column is truly absent,
         // avoiding a broad catch that would hide real DB errors (locking, corruption, etc.).
-        foreach (string col in new[] { "channels_ok", "channels_failed" })
+        foreach ((string col, string ddl) in new (string, string)[]
+        {
+            ("channels_ok",   "channels_ok TEXT"),
+            ("channels_failed", "channels_failed TEXT"),
+            ("retry_count",   "retry_count INTEGER NOT NULL DEFAULT 0"),
+            ("next_retry_at", "next_retry_at TEXT"),
+        })
         {
             using SqliteCommand pragmaCmd = conn.CreateCommand();
             pragmaCmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('notification_sent') WHERE name = @col";
@@ -77,7 +83,7 @@ internal sealed class InvoiceCache
             if (exists == 0)
             {
                 using SqliteCommand alter = conn.CreateCommand();
-                alter.CommandText = $"ALTER TABLE notification_sent ADD COLUMN {col} TEXT";
+                alter.CommandText = $"ALTER TABLE notification_sent ADD COLUMN {ddl}";
                 alter.ExecuteNonQuery();
             }
         }
@@ -268,18 +274,26 @@ internal sealed class InvoiceCache
         using SqliteTransaction tx = conn.BeginTransaction();
         using SqliteCommand cmd = conn.CreateCommand();
         cmd.Transaction = tx;
+        // When any channel fails, schedule the first retry in 5 minutes (retry_count = 0).
+        // If all channels succeed, clear the retry schedule.
+        string? nextRetryAt = failed is not null ? DateTime.UtcNow.AddMinutes(5).ToString("o") : null;
         cmd.CommandText = """
             UPDATE notification_sent
-            SET channels_ok = @ok, channels_failed = @failed
+            SET channels_ok    = @ok,
+                channels_failed = @failed,
+                retry_count    = CASE WHEN @failed IS NOT NULL THEN 0 ELSE retry_count END,
+                next_retry_at  = CASE WHEN @failed IS NOT NULL THEN @nextAt ELSE NULL END
             WHERE profile_key = @key AND ksef_number = @ksef
             """;
         SqliteParameter pKey = cmd.Parameters.Add("@key", SqliteType.Text);
         SqliteParameter pKsef = cmd.Parameters.Add("@ksef", SqliteType.Text);
         SqliteParameter pOk = cmd.Parameters.Add("@ok", SqliteType.Text);
         SqliteParameter pFailed = cmd.Parameters.Add("@failed", SqliteType.Text);
+        SqliteParameter pNextAt = cmd.Parameters.Add("@nextAt", SqliteType.Text);
         pKey.Value = profileKey;
         pOk.Value = ok is not null ? (object)ok : DBNull.Value;
         pFailed.Value = failed is not null ? (object)failed : DBNull.Value;
+        pNextAt.Value = nextRetryAt is not null ? (object)nextRetryAt : DBNull.Value;
         cmd.Prepare();
         foreach (string ksefNumber in ksefNumbers)
         {
@@ -288,7 +302,7 @@ internal sealed class InvoiceCache
         }
         tx.Commit();
         string summary = ok is not null ? $"ok=[{ok}]" : "ok=[]";
-        if (failed is not null) { summary += $" failed=[{failed}]"; }
+        if (failed is not null) { summary += $" failed=[{failed}] retry_in=5m"; }
         Log.LogInformation($"[notif-sent] Channel outcomes recorded for profile key {profileKey[..Math.Min(24, profileKey.Length)]}… — {summary}");
     }
 
@@ -311,10 +325,165 @@ internal sealed class InvoiceCache
         return deleted;
     }
 
+    /// <summary>
+    /// Returns all notification_sent rows for this profile where at least one channel failed and
+    /// the row is eligible for retry: retry_count &lt; 3 and next_retry_at has elapsed (or is NULL).
+    /// Backoff schedule: initial = 5 min, retry 1 = 10 min, retry 2 = 20 min, then no more.
+    /// </summary>
+    public List<PendingRetry> LoadPendingRetries(string profileKey)
+    {
+        string now = DateTime.UtcNow.ToString("o");
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT ksef_number, channels_ok, channels_failed, retry_count
+            FROM notification_sent
+            WHERE profile_key    = @key
+              AND channels_failed IS NOT NULL
+              AND retry_count     < 3
+              AND (next_retry_at IS NULL OR next_retry_at <= @now)
+            ORDER BY sent_at
+            """;
+        cmd.Parameters.AddWithValue("@key", profileKey);
+        cmd.Parameters.AddWithValue("@now", now);
+        using SqliteDataReader reader = cmd.ExecuteReader();
+        List<PendingRetry> result = [];
+        while (reader.Read())
+        {
+            string ksefNumber = reader.GetString(0);
+            string? channelsOk = reader.IsDBNull(1) ? null : reader.GetString(1);
+            string channelsFailed = reader.GetString(2);
+            int retryCount = reader.GetInt32(3);
+            List<string> failedList = [.. channelsFailed.Split(',').Where(s => !string.IsNullOrEmpty(s))];
+            result.Add(new PendingRetry(ksefNumber, channelsOk, failedList, retryCount));
+        }
+        if (result.Count > 0)
+        {
+            Log.LogDebug($"[notif-retry] {result.Count} pending retry row(s) for profile key {profileKey[..Math.Min(24, profileKey.Length)]}…");
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Records the outcome of a retry attempt. Merges newly-ok channels with existing ones,
+    /// updates still-failed channels, increments retry_count, and schedules the next retry
+    /// using exponential backoff (10 min for retry 1, 20 min for retry 2). Stops after 3 retries.
+    /// </summary>
+    public void UpdateRetryOutcome(string profileKey, IEnumerable<string> ksefNumbers,
+        IReadOnlyList<string> channelsOk, IReadOnlyList<string> channelsFailed, int retryCount)
+    {
+        string? ok = channelsOk.Count > 0 ? string.Join(",", channelsOk) : null;
+        string? failed = channelsFailed.Count > 0 ? string.Join(",", channelsFailed) : null;
+        // Backoff: retryCount=1 → 10 min, retryCount=2 → 20 min, retryCount=3 → done
+        string? nextRetryAt = failed is not null && retryCount < 3
+            ? DateTime.UtcNow.AddMinutes(5 * (1 << retryCount)).ToString("o")
+            : null;
+
+        using SqliteConnection conn = Open();
+        using SqliteTransaction tx = conn.BeginTransaction();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText = """
+            UPDATE notification_sent
+            SET channels_ok    = @ok,
+                channels_failed = @failed,
+                retry_count    = @retryCount,
+                next_retry_at  = @nextAt
+            WHERE profile_key = @key AND ksef_number = @ksef
+            """;
+        SqliteParameter pKey = cmd.Parameters.Add("@key", SqliteType.Text);
+        SqliteParameter pKsef = cmd.Parameters.Add("@ksef", SqliteType.Text);
+        SqliteParameter pOk = cmd.Parameters.Add("@ok", SqliteType.Text);
+        SqliteParameter pFailed = cmd.Parameters.Add("@failed", SqliteType.Text);
+        SqliteParameter pRetry = cmd.Parameters.Add("@retryCount", SqliteType.Integer);
+        SqliteParameter pNextAt = cmd.Parameters.Add("@nextAt", SqliteType.Text);
+        pKey.Value = profileKey;
+        pOk.Value = ok is not null ? (object)ok : DBNull.Value;
+        pFailed.Value = failed is not null ? (object)failed : DBNull.Value;
+        pRetry.Value = retryCount;
+        pNextAt.Value = nextRetryAt is not null ? (object)nextRetryAt : DBNull.Value;
+        cmd.Prepare();
+        foreach (string ksefNumber in ksefNumbers)
+        {
+            pKsef.Value = ksefNumber;
+            cmd.ExecuteNonQuery();
+        }
+        tx.Commit();
+        string summary = ok is not null ? $"ok=[{ok}]" : "ok=[]";
+        if (failed is not null)
+        {
+            string backoffLabel = retryCount < 3 ? $"next={5 * (1 << retryCount)}m" : "max-retries-reached";
+            summary += $" failed=[{failed}] retry_count={retryCount} {backoffLabel}";
+        }
+        Log.LogInformation($"[notif-retry] Outcome for profile key {profileKey[..Math.Min(24, profileKey.Length)]}… — {summary}");
+    }
+
+    /// <summary>
+    /// Returns the most recent notification row for this profile plus a count of rows
+    /// pending retry. Used by the /notification-status UI endpoint.
+    /// </summary>
+    public NotificationStatus LoadNotificationStatus(string profileKey)
+    {
+        string now = DateTime.UtcNow.ToString("o");
+        using SqliteConnection conn = Open();
+
+        using SqliteCommand latestCmd = conn.CreateCommand();
+        latestCmd.CommandText = """
+            SELECT sent_at, channels_ok, channels_failed, retry_count
+            FROM notification_sent
+            WHERE profile_key = @key
+            ORDER BY sent_at DESC
+            LIMIT 1
+            """;
+        latestCmd.Parameters.AddWithValue("@key", profileKey);
+        string? lastSentAt = null, lastOk = null, lastFailed = null;
+        int? lastRetryCount = null;
+        using (SqliteDataReader reader = latestCmd.ExecuteReader())
+        {
+            if (reader.Read())
+            {
+                lastSentAt = reader.IsDBNull(0) ? null : reader.GetString(0);
+                lastOk = reader.IsDBNull(1) ? null : reader.GetString(1);
+                lastFailed = reader.IsDBNull(2) ? null : reader.GetString(2);
+                lastRetryCount = reader.IsDBNull(3) ? null : reader.GetInt32(3);
+            }
+        }
+
+        using SqliteCommand pendingCmd = conn.CreateCommand();
+        pendingCmd.CommandText = """
+            SELECT COUNT(DISTINCT ksef_number)
+            FROM notification_sent
+            WHERE profile_key    = @key
+              AND channels_failed IS NOT NULL
+              AND retry_count     < 3
+              AND (next_retry_at IS NULL OR next_retry_at <= @now)
+            """;
+        pendingCmd.Parameters.AddWithValue("@key", profileKey);
+        pendingCmd.Parameters.AddWithValue("@now", now);
+        int pendingRetries = (int)(long)(pendingCmd.ExecuteScalar() ?? 0L);
+
+        return new NotificationStatus(lastSentAt, pendingRetries, lastOk, lastFailed, lastRetryCount);
+    }
+
     private SqliteConnection Open()
     {
         SqliteConnection conn = new SqliteConnection($"Data Source={_dbPath}");
         conn.Open();
         return conn;
     }
+
+    /// <summary>A notification_sent row eligible for retry delivery.</summary>
+    public record PendingRetry(
+        string KsefNumber,
+        string? ChannelsOk,
+        List<string> ChannelsFailed,
+        int RetryCount);
+
+    /// <summary>Snapshot of the most recent notification state for a profile, used by the UI status badge.</summary>
+    public record NotificationStatus(
+        string? LastSentAt,
+        int PendingRetries,
+        string? LastChannelsOk,
+        string? LastChannelsFailed,
+        int? LastRetryCount);
 }

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -375,8 +375,9 @@ internal sealed class InvoiceCache
         string? ok = channelsOk.Count > 0 ? string.Join(",", channelsOk) : null;
         string? failed = channelsFailed.Count > 0 ? string.Join(",", channelsFailed) : null;
         // Backoff: retryCount=1 → 10 min, retryCount=2 → 20 min, retryCount=3 → done
+        double backoffMinutes = 5.0 * Math.Pow(2, retryCount);
         string? nextRetryAt = failed is not null && retryCount < 3
-            ? DateTime.UtcNow.AddMinutes(5 * (1 << retryCount)).ToString("o")
+            ? DateTime.UtcNow.AddMinutes(backoffMinutes).ToString("o")
             : null;
 
         using SqliteConnection conn = Open();
@@ -412,7 +413,7 @@ internal sealed class InvoiceCache
         string summary = ok is not null ? $"ok=[{ok}]" : "ok=[]";
         if (failed is not null)
         {
-            string backoffLabel = retryCount < 3 ? $"next={5 * (1 << retryCount)}m" : "max-retries-reached";
+            string backoffLabel = retryCount < 3 ? $"next={backoffMinutes}m" : "max-retries-reached";
             summary += $" failed=[{failed}] retry_count={retryCount} {backoffLabel}";
         }
         Log.LogInformation($"[notif-retry] Outcome for profile key {profileKey[..Math.Min(24, profileKey.Length)]}… — {summary}");
@@ -424,7 +425,6 @@ internal sealed class InvoiceCache
     /// </summary>
     public NotificationStatus LoadNotificationStatus(string profileKey)
     {
-        string now = DateTime.UtcNow.ToString("o");
         using SqliteConnection conn = Open();
 
         using SqliteCommand latestCmd = conn.CreateCommand();
@@ -456,10 +456,8 @@ internal sealed class InvoiceCache
             WHERE profile_key    = @key
               AND channels_failed IS NOT NULL
               AND retry_count     < 3
-              AND (next_retry_at IS NULL OR next_retry_at <= @now)
             """;
         pendingCmd.Parameters.AddWithValue("@key", profileKey);
-        pendingCmd.Parameters.AddWithValue("@now", now);
         int pendingRetries = (int)(long)(pendingCmd.ExecuteScalar() ?? 0L);
 
         return new NotificationStatus(lastSentAt, pendingRetries, lastOk, lastFailed, lastRetryCount);

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -66,6 +66,10 @@ internal sealed class WebProgressServer : IDisposable
     /// Returns a result message string.</summary>
     public Func<string, CancellationToken, Task<string>>? OnTestEmail { get; set; }
 
+    /// <summary>Called to fetch notification delivery status per profile.
+    /// Returns an object keyed by profile name with last-sent, pending-retry, and error state.</summary>
+    public Func<Task<object>>? OnNotificationStatus { get; set; }
+
     public bool Lan { get; }
 
     /// <summary>
@@ -460,6 +464,16 @@ internal sealed class WebProgressServer : IDisposable
                     ? await OnTestEmail(body, ct).ConfigureAwait(false)
                     : "Brak obsługi testu e-mail.";
                 return JsonSerializer.Serialize(new { ok = true, message = result });
+            }).ConfigureAwait(false);
+        }
+        else if (path == "/notification-status" && method == "GET")
+        {
+            await HandleAction(ctx, ct, async () =>
+            {
+                object data = OnNotificationStatus != null
+                    ? await OnNotificationStatus().ConfigureAwait(false)
+                    : new { };
+                return JsonSerializer.Serialize(data, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
             }).ConfigureAwait(false);
         }
         else if (path == "/quit" && method == "POST")
@@ -1301,10 +1315,12 @@ function updateAuthButton() {
   }
 }
 
-// Fetch token status on load and periodically
+// Fetch token and notification status on load and periodically
 fetchTokenStatus();
+fetchNotifStatus();
 setInterval(() => { updateAuthButton(); }, 15000);
 setInterval(() => { fetchTokenStatus(); }, 60000);
+setInterval(() => { fetchNotifStatus(); }, 120000);
 
 async function savePrefs() {
   const prefs = {
@@ -1931,6 +1947,16 @@ function connectSSE() {
           markProfileBadge(d.profileName, d.newCount);
           notifyNewInvoices(d.profileName, d.newCount);
         }
+        fetchNotifStatus();
+        break;
+      case 'notification_outcome':
+        // d = { profileName, isRetry, channelsOk, channelsFailed, pendingRetries? }
+        if (d.channelsFailed && d.channelsFailed.length > 0) {
+          console.warn('[notif] Delivery failed for profile "' + d.profileName + '",' +
+            (d.isRetry ? ' retry' : ' initial') +
+            ' channels: [' + d.channelsFailed.join(', ') + ']');
+        }
+        fetchNotifStatus();
         break;
     }
   };
@@ -1953,15 +1979,33 @@ function markProfileBadge(name, count) {
   updateProfileSelectBadges();
 }
 
+const notifStatusBadges = {}; // profileName → { pendingRetries, lastSentAt, hasErrors }
+
 function updateProfileSelectBadges() {
   const sel = $('profileSelect');
   if (!sel) return;
   for (const opt of sel.options) {
-    const badge = profileBadges[opt.value];
+    const invBadge = profileBadges[opt.value];
+    const notif = notifStatusBadges[opt.value];
     const base = opt.dataset.base || opt.textContent;
     opt.dataset.base = base;
-    opt.textContent = badge ? base + ' \uD83D\uDD14' + badge : base;
+    let label = base;
+    if (invBadge) { label += ' \uD83D\uDD14' + invBadge; }
+    if (notif && notif.pendingRetries > 0) { label += ' \u26A0\uFE0F' + notif.pendingRetries; }
+    opt.textContent = label;
   }
+}
+
+async function fetchNotifStatus() {
+  try {
+    const res = await fetch('/notification-status');
+    if (!res.ok) { return; }
+    const data = await res.json();
+    for (const [name, status] of Object.entries(data)) {
+      notifStatusBadges[name] = status;
+    }
+    updateProfileSelectBadges();
+  } catch (e) { /* ignore — server may not be ready yet */ }
 }
 
 // Extensible notification hook — swap for email/Slack in future


### PR DESCRIPTION
Implements exponential backoff for webhook delivery failures

- Adds retry logic with 5/10/20 minute intervals (max 3 attempts)
- Tracks notification status per profile with pending retry counts
- Enhances logging with host information and error details
- Adds status endpoint for UI notification badges
- Sends real-time events for delivery outcomes
- Updates database schema to support retry scheduling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry mechanism for failed notification deliveries with exponential backoff and per-profile retry tracking
  * Server endpoint and UI support to surface per-profile notification status (last sent, pending retries, per-channel health)

* **Improvements**
  * Enhanced diagnostic logging for Slack, Teams, and Email with richer host/context and error details
  * Notification status badges auto-refresh on background events and periodic polling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->