### PR TITLE
feat: adds KSeF reference number support to PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,49 @@ PDF generowany **natywnie** przez [QuestPDF](https://www.questpdf.com/) — czys
 | `forest`            | Ciemna zieleń — świeży akcent  |
 | `slate`             | Ciemny szary — minimalistyczny |
 
+#### Pola FA(3) renderowane w PDF
+
+Pola wyodrębniane z XML faktury KSeF (schemat FA(3)) i uwzględniane w generowanym pliku PDF:
+
+| Sekcja XML | Pole / element | Opis |
+| --- | --- | --- |
+| `Naglowek` | `SystemInfo` | System wystawiający fakturę (stopka) |
+| _(metadane API)_ | `KsefReferenceNumber` | **Numer KSeF** (przekazywany z odpowiedzi API, nie z XML) |
+| `Fa` | `P_2` | Numer faktury wystawcy |
+| `Fa` | `RodzajFaktury` | Typ dokumentu (VAT, KOR, ZAL…) |
+| `Fa` | `P_1` | Data wystawienia |
+| `Fa` | `P_1M` | Miejsce wystawienia |
+| `Fa` | `P_6` | Data dostawy / wykonania usługi |
+| `Fa` › `OkresFa` | `P_6_Od`, `P_6_Do` | Okres rozliczeniowy (od–do) |
+| `Fa` › `FakturaZaliczkowa` | `NrFaZaliczkowej` | Numer faktury zaliczkowej |
+| `Fa` | `KodWaluty` | Waluta |
+| `Podmiot1` | `NIP`, `Nazwa` | NIP i nazwa sprzedawcy |
+| `Podmiot1` › `Adres` | `KodKraju`, `AdresL1`, `AdresL2` | Adres sprzedawcy |
+| `Podmiot1` › `DaneKontaktowe` | `Email`, `Telefon` | Kontakt sprzedawcy |
+| `Podmiot1` | `NrEORI` | Numer EORI sprzedawcy |
+| `Podmiot2` | `NIP`, `Nazwa` | NIP i nazwa nabywcy |
+| `Podmiot2` › `Adres` | `KodKraju`, `AdresL1`, `AdresL2` | Adres nabywcy |
+| `Podmiot2` › `DaneKontaktowe` | `Email` | E-mail nabywcy |
+| `Podmiot2` | `NrKlienta` | Numer klienta nabywcy |
+| `Fa` › `FaWiersz` | `NrWierszaFa` | Numer wiersza |
+| `Fa` › `FaWiersz` | `P_7` | Nazwa towaru/usługi |
+| `Fa` › `FaWiersz` | `P_8A`, `P_8B` | Jednostka miary, ilość |
+| `Fa` › `FaWiersz` | `P_9A`, `P_9B` | Cena jednostkowa netto / brutto |
+| `Fa` › `FaWiersz` | `P_11`, `P_11A` | Wartość netto / brutto |
+| `Fa` › `FaWiersz` | `P_12` | Stawka VAT |
+| `Fa` › `FaWiersz` | `KursWaluty` | Kurs waluty pozycji |
+| `Fa` › `FaWiersz` | `Indeks`, `GTIN`, `UU_ID` | Identyfikatory towaru |
+| `Fa` | `P_13_x`, `P_14_x` | Sumy netto i VAT per stawka |
+| `Fa` | `P_15` | Kwota należności ogółem (brutto) |
+| `Fa` › `Platnosc` | `FormaPlatnosci` | Forma płatności |
+| `Fa` › `Platnosc` | `TerminPlatnosci` / `Termin` | Termin(y) płatności |
+| `Fa` › `Platnosc` | `Zaplacono`, `DataZaplaty` | Znacznik zapłacono / data |
+| `Fa` › `Platnosc` › `RachunekBankowy` | `NrRB`, `NazwaBanku`, `OpisRachunku` | Dane rachunku bankowego |
+| `Fa` | `DodatkowyOpis` (`Klucz`, `Wartosc`) | Dodatkowe opisy (pary klucz–wartość) |
+| `Fa` | `WZ` | Numer dokumentu WZ |
+| `Fa` › `WarunkiTransakcji` › `Umowy` | `NrUmowy` | Numery umów |
+| `Stopka` › `Rejestry` | `PelnaNazwa`, `REGON`, `BDO` | Dane rejestrowe sprzedawcy |
+
 ---
 
 ## English
@@ -590,6 +633,49 @@ PDFs are rendered by a **native built-in engine** using [QuestPDF](https://www.q
 | `navy` _(default)_ | Dark navy — classic, formal  |
 | `forest`           | Dark green — fresh accent    |
 | `slate`            | Dark grey — neutral, minimal |
+
+#### FA(3) fields rendered in PDF
+
+Fields extracted from KSeF invoice XML (FA(3) schema) and included in the generated PDF:
+
+| XML section | Field / element | Description |
+| --- | --- | --- |
+| `Naglowek` | `SystemInfo` | Issuing system name (footer) |
+| _(API metadata)_ | `KsefReferenceNumber` | **KSeF number** (injected from API response, not from XML) |
+| `Fa` | `P_2` | Issuer's invoice number |
+| `Fa` | `RodzajFaktury` | Document type (VAT, KOR, ZAL…) |
+| `Fa` | `P_1` | Issue date |
+| `Fa` | `P_1M` | Place of issue |
+| `Fa` | `P_6` | Delivery / service completion date |
+| `Fa` › `OkresFa` | `P_6_Od`, `P_6_Do` | Settlement period (from–to) |
+| `Fa` › `FakturaZaliczkowa` | `NrFaZaliczkowej` | Advance invoice number |
+| `Fa` | `KodWaluty` | Currency code |
+| `Podmiot1` | `NIP`, `Nazwa` | Seller tax ID and name |
+| `Podmiot1` › `Adres` | `KodKraju`, `AdresL1`, `AdresL2` | Seller address |
+| `Podmiot1` › `DaneKontaktowe` | `Email`, `Telefon` | Seller contact |
+| `Podmiot1` | `NrEORI` | Seller EORI number |
+| `Podmiot2` | `NIP`, `Nazwa` | Buyer tax ID and name |
+| `Podmiot2` › `Adres` | `KodKraju`, `AdresL1`, `AdresL2` | Buyer address |
+| `Podmiot2` › `DaneKontaktowe` | `Email` | Buyer e-mail |
+| `Podmiot2` | `NrKlienta` | Buyer customer number |
+| `Fa` › `FaWiersz` | `NrWierszaFa` | Line number |
+| `Fa` › `FaWiersz` | `P_7` | Item / service name |
+| `Fa` › `FaWiersz` | `P_8A`, `P_8B` | Unit of measure, quantity |
+| `Fa` › `FaWiersz` | `P_9A`, `P_9B` | Unit net / gross price |
+| `Fa` › `FaWiersz` | `P_11`, `P_11A` | Net / gross line total |
+| `Fa` › `FaWiersz` | `P_12` | VAT rate |
+| `Fa` › `FaWiersz` | `KursWaluty` | Line exchange rate |
+| `Fa` › `FaWiersz` | `Indeks`, `GTIN`, `UU_ID` | Item identifiers |
+| `Fa` | `P_13_x`, `P_14_x` | Net and VAT subtotals per rate |
+| `Fa` | `P_15` | Total gross amount |
+| `Fa` › `Platnosc` | `FormaPlatnosci` | Payment method |
+| `Fa` › `Platnosc` | `TerminPlatnosci` / `Termin` | Payment due date(s) |
+| `Fa` › `Platnosc` | `Zaplacono`, `DataZaplaty` | Paid flag / payment date |
+| `Fa` › `Platnosc` › `RachunekBankowy` | `NrRB`, `NazwaBanku`, `OpisRachunku` | Bank account details |
+| `Fa` | `DodatkowyOpis` (`Klucz`, `Wartosc`) | Additional notes (key–value pairs) |
+| `Fa` | `WZ` | WZ document reference |
+| `Fa` › `WarunkiTransakcji` › `Umowy` | `NrUmowy` | Contract number(s) |
+| `Stopka` › `Rejestry` | `PelnaNazwa`, `REGON`, `BDO` | Seller registry data |
 
 ---
 

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -18,19 +18,6 @@ public class PdfGenerationTests
         pdf[0] == (byte)'%' && pdf[1] == (byte)'P' &&
         pdf[2] == (byte)'D' && pdf[3] == (byte)'F';
 
-    private static bool ContainsSubsequence(byte[] haystack, byte[] needle)
-    {
-        int limit = haystack.Length - needle.Length;
-        for (int i = 0; i <= limit; i++)
-        {
-            if (haystack.AsSpan(i, needle.Length).SequenceEqual(needle))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
     // ── PDF byte sanity ───────────────────────────────────────────────────────
 
     [Fact]
@@ -96,14 +83,12 @@ public class PdfGenerationTests
     {
         // A string longer than 256 chars must be truncated — the result must still be a valid PDF.
         string oversize = new('X', 300);
-        byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, oversize);
-        Assert.True(IsPdfHeader(pdf));
-        Assert.True(pdf.Length > 1024);
         string expectedTruncated = oversize.Substring(0, 256);
-        byte[] truncatedBytes = System.Text.Encoding.UTF8.GetBytes(expectedTruncated);
-        byte[] oversizeBytes = System.Text.Encoding.UTF8.GetBytes(oversize);
-        Assert.True(ContainsSubsequence(pdf, truncatedBytes), "Truncated 256-char prefix should appear in PDF bytes");
-        Assert.False(ContainsSubsequence(pdf, oversizeBytes), "Full 300-char oversize string should not appear in PDF bytes");
+        byte[] pdfFromOversize = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, oversize);
+        byte[] pdfFromTruncated = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, expectedTruncated);
+        Assert.True(IsPdfHeader(pdfFromOversize));
+        Assert.True(pdfFromOversize.Length > 1024);
+        Assert.Equal(pdfFromTruncated, pdfFromOversize);
     }
 
     [Fact]

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -66,14 +66,37 @@ public class PdfGenerationTests
         Assert.True(IsPdfHeader(pdf), "Expected %PDF header when KSeF number is omitted");
     }
 
-    [Fact]
-    public void GeneratePdf_WithKsefReferenceNumber_IsLargerThanWithout()
+    [Theory]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void FromXml_WhitespaceOnlyKsefReferenceNumber_TreatedAsNull(string whitespace)
     {
-        // A QR code image is embedded when a KSeF number is provided;
+        // Whitespace-only inputs must be normalized to null — the PDF must be identical to passing null.
+        byte[] pdfWithWhitespace = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, whitespace);
+        byte[] pdfWithNull = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null);
+        Assert.True(IsPdfHeader(pdfWithWhitespace));
+        Assert.Equal(pdfWithNull.Length, pdfWithWhitespace.Length);
+    }
+
+    [Fact]
+    public void FromXml_OversizedKsefReferenceNumber_TruncatesAndReturnsPdf()
+    {
+        // A string longer than 256 chars must be truncated — the result must still be a valid PDF.
+        string oversize = new('X', 300);
+        byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, oversize);
+        Assert.True(IsPdfHeader(pdf));
+        Assert.True(pdf.Length > 1024);
+    }
+
+    [Fact]
+    public void GeneratePdf_WithKsefVerificationUrl_IsLargerThanWithout()
+    {
+        // A QR code image is embedded when a KSeF verification URL is provided;
         // the resulting PDF must be strictly larger than one without it.
+        const string VerificationUrl = "https://qr.ksef.mf.gov.pl/invoice/9999999999/15-03-2024/AAABBBCCC";
         byte[] pdfWithQr = KSeFInvoicePdf.FromXml(
-            LoadSampleXml(), null, "9999999999-20240315-ABCDEF123456-01");
-        byte[] pdfWithout = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null);
+            LoadSampleXml(), null, "9999999999-20240315-ABCDEF123456-01", VerificationUrl);
+        byte[] pdfWithout = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null, null);
         Assert.True(
             pdfWithQr.Length > pdfWithout.Length,
             $"Expected PDF with QR ({pdfWithQr.Length} B) to be larger than without ({pdfWithout.Length} B)");

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -202,7 +202,7 @@ public class PdfGenerationTests
     }
 
     [Fact]
-    public void FromXml_KsefReferenceNumber_PassedThroughToData()
+    public void ParserAndSanitizer_PreserveKsefReferenceNumber()
     {
         // Verify the number survives the Sanitize step and arrives at the generator.
         // We test via the parser+sanitize pipeline rather than byte-scanning the PDF.

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -75,7 +75,10 @@ public class PdfGenerationTests
         byte[] pdfWithWhitespace = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, whitespace);
         byte[] pdfWithNull = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null);
         Assert.True(IsPdfHeader(pdfWithWhitespace));
-        Assert.Equal(pdfWithNull, pdfWithWhitespace);
+        // Byte-equality is fragile because the PDF embeds a creation timestamp.
+        // Length equality is sufficient: a PDF with a KSeF reference number is strictly
+        // longer, so equal length confirms whitespace was treated as null.
+        Assert.Equal(pdfWithNull.Length, pdfWithWhitespace.Length);
     }
 
     [Fact]
@@ -88,7 +91,9 @@ public class PdfGenerationTests
         byte[] pdfFromTruncated = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, expectedTruncated);
         Assert.True(IsPdfHeader(pdfFromOversize));
         Assert.True(pdfFromOversize.Length > 1024);
-        Assert.Equal(pdfFromTruncated, pdfFromOversize);
+        // Byte-equality is fragile due to embedded PDF creation timestamps; length equality
+        // is sufficient because both inputs truncate to the same 256-char string.
+        Assert.Equal(pdfFromTruncated.Length, pdfFromOversize.Length);
     }
 
     [Fact]

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -66,6 +66,19 @@ public class PdfGenerationTests
         Assert.True(IsPdfHeader(pdf), "Expected %PDF header when KSeF number is omitted");
     }
 
+    [Fact]
+    public void GeneratePdf_WithKsefReferenceNumber_IsLargerThanWithout()
+    {
+        // A QR code image is embedded when a KSeF number is provided;
+        // the resulting PDF must be strictly larger than one without it.
+        byte[] pdfWithQr = KSeFInvoicePdf.FromXml(
+            LoadSampleXml(), null, "9999999999-20240315-ABCDEF123456-01");
+        byte[] pdfWithout = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null);
+        Assert.True(
+            pdfWithQr.Length > pdfWithout.Length,
+            $"Expected PDF with QR ({pdfWithQr.Length} B) to be larger than without ({pdfWithout.Length} B)");
+    }
+
     // ── Parser field coverage ─────────────────────────────────────────────────
 
     [Fact]

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -14,9 +14,22 @@ public class PdfGenerationTests
     }
 
     private static bool IsPdfHeader(byte[] pdf) =>
-        pdf.Length > 4 &&
+        pdf.Length >= 4 &&
         pdf[0] == (byte)'%' && pdf[1] == (byte)'P' &&
         pdf[2] == (byte)'D' && pdf[3] == (byte)'F';
+
+    private static bool ContainsSubsequence(byte[] haystack, byte[] needle)
+    {
+        int limit = haystack.Length - needle.Length;
+        for (int i = 0; i <= limit; i++)
+        {
+            if (haystack.AsSpan(i, needle.Length).SequenceEqual(needle))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     // ── PDF byte sanity ───────────────────────────────────────────────────────
 
@@ -75,7 +88,7 @@ public class PdfGenerationTests
         byte[] pdfWithWhitespace = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, whitespace);
         byte[] pdfWithNull = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null);
         Assert.True(IsPdfHeader(pdfWithWhitespace));
-        Assert.Equal(pdfWithNull.Length, pdfWithWhitespace.Length);
+        Assert.Equal(pdfWithNull, pdfWithWhitespace);
     }
 
     [Fact]
@@ -86,6 +99,11 @@ public class PdfGenerationTests
         byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, oversize);
         Assert.True(IsPdfHeader(pdf));
         Assert.True(pdf.Length > 1024);
+        string expectedTruncated = oversize.Substring(0, 256);
+        byte[] truncatedBytes = System.Text.Encoding.UTF8.GetBytes(expectedTruncated);
+        byte[] oversizeBytes = System.Text.Encoding.UTF8.GetBytes(oversize);
+        Assert.True(ContainsSubsequence(pdf, truncatedBytes), "Truncated 256-char prefix should appear in PDF bytes");
+        Assert.False(ContainsSubsequence(pdf, oversizeBytes), "Full 300-char oversize string should not appear in PDF bytes");
     }
 
     [Fact]

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -13,17 +13,19 @@ public class PdfGenerationTests
         return File.ReadAllText(path);
     }
 
+    private static bool IsPdfHeader(byte[] pdf) =>
+        pdf.Length > 4 &&
+        pdf[0] == (byte)'%' && pdf[1] == (byte)'P' &&
+        pdf[2] == (byte)'D' && pdf[3] == (byte)'F';
+
+    // ── PDF byte sanity ───────────────────────────────────────────────────────
+
     [Fact]
     public void GeneratePdf_DefaultScheme_ReturnsPdfBytes()
     {
-        string xml = LoadSampleXml();
-        byte[] pdf = KSeFInvoicePdf.FromXml(xml);
-        Assert.NotNull(pdf);
+        byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml());
+        Assert.True(IsPdfHeader(pdf), "Expected %PDF header");
         Assert.True(pdf.Length > 1024, "PDF should be larger than 1 KB");
-        Assert.Equal((byte)'%', pdf[0]);
-        Assert.Equal((byte)'P', pdf[1]);
-        Assert.Equal((byte)'D', pdf[2]);
-        Assert.Equal((byte)'F', pdf[3]);
     }
 
     [Theory]
@@ -32,14 +34,9 @@ public class PdfGenerationTests
     [InlineData("slate")]
     public void GeneratePdf_NamedScheme_ReturnsPdfBytes(string scheme)
     {
-        string xml = LoadSampleXml();
-        byte[] pdf = KSeFInvoicePdf.FromXml(xml, scheme);
-        Assert.NotNull(pdf);
-        Assert.True(pdf.Length > 1024, $"PDF with scheme '{scheme}' should be larger than 1 KB");
-        Assert.Equal((byte)'%', pdf[0]);
-        Assert.Equal((byte)'P', pdf[1]);
-        Assert.Equal((byte)'D', pdf[2]);
-        Assert.Equal((byte)'F', pdf[3]);
+        byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml(), scheme);
+        Assert.True(IsPdfHeader(pdf), $"Expected %PDF header for scheme '{scheme}'");
+        Assert.True(pdf.Length > 1024);
     }
 
     [Theory]
@@ -48,13 +45,160 @@ public class PdfGenerationTests
     [InlineData("unknown-scheme")]
     public void GeneratePdf_FallbackScheme_ReturnsPdfBytes(string? scheme)
     {
-        string xml = LoadSampleXml();
-        byte[] pdf = KSeFInvoicePdf.FromXml(xml, scheme);
-        Assert.NotNull(pdf);
+        byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml(), scheme);
+        Assert.True(IsPdfHeader(pdf));
         Assert.True(pdf.Length > 1024);
-        Assert.Equal((byte)'%', pdf[0]);
-        Assert.Equal((byte)'P', pdf[1]);
-        Assert.Equal((byte)'D', pdf[2]);
-        Assert.Equal((byte)'F', pdf[3]);
+    }
+
+    [Fact]
+    public void GeneratePdf_WithKsefReferenceNumber_ReturnsPdfBytes()
+    {
+        byte[] pdf = KSeFInvoicePdf.FromXml(
+            LoadSampleXml(), null, "9999999999-20240315-ABCDEF123456-01");
+        Assert.True(IsPdfHeader(pdf), "Expected %PDF header when KSeF number is provided");
+        Assert.True(pdf.Length > 1024);
+    }
+
+    [Fact]
+    public void GeneratePdf_WithoutKsefReferenceNumber_ReturnsPdfBytes()
+    {
+        byte[] pdf = KSeFInvoicePdf.FromXml(LoadSampleXml(), null, null);
+        Assert.True(IsPdfHeader(pdf), "Expected %PDF header when KSeF number is omitted");
+    }
+
+    // ── Parser field coverage ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseInvoice_HeaderFields_AreCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal("VAT", d.RodzajFaktury);
+        Assert.Equal("FV/2024/03/001", d.Numer);
+        Assert.Equal("2024-03-15", d.DataFaktury);
+        Assert.Equal("Warszawa", d.MiejsceWystawienia);
+        Assert.Equal("2024-03-15", d.DataDostawy);
+        Assert.Equal("PLN", d.Waluta);
+        Assert.Equal("TestSystem v1.0", d.SystemInfo);
+    }
+
+    [Fact]
+    public void ParseInvoice_KsefReferenceNumber_IsNullFromXml()
+    {
+        // KSeF number is not in the XML — it comes from API metadata.
+        // Parser must always return null; FromXml injects it afterwards.
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Null(d.KsefReferenceNumber);
+    }
+
+    [Fact]
+    public void ParseInvoice_Seller_IsCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal("1234567890", d.Sprzedawca.Nip);
+        Assert.Equal("Testowa Firma Sp. z o.o.", d.Sprzedawca.Nazwa);
+        Assert.Equal("PL", d.Sprzedawca.KodKraju);
+        Assert.Equal("ul. Przykładowa 1", d.Sprzedawca.AdresL1);
+        Assert.Equal("00-001 Warszawa", d.Sprzedawca.AdresL2);
+        Assert.Equal("kontakt@testowafirma.example", d.Sprzedawca.Email);
+        Assert.Equal("+48 123 456 789", d.Sprzedawca.Telefon);
+    }
+
+    [Fact]
+    public void ParseInvoice_Buyer_IsCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal("0987654321", d.Nabywca.Nip);
+        Assert.Equal("Nabywca Testowy S.A.", d.Nabywca.Nazwa);
+        Assert.Equal("ul. Fikcyjna 42", d.Nabywca.AdresL1);
+        Assert.Equal("31-001 Kraków", d.Nabywca.AdresL2);
+        Assert.Equal("faktury@nabywca.example", d.Nabywca.Email);
+        Assert.Equal("KLIENT-001", d.Nabywca.NrKlienta);
+    }
+
+    [Fact]
+    public void ParseInvoice_LineItems_AreCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal(3, d.Wiersze.Count);
+
+        InvoiceLine line1 = d.Wiersze[0];
+        Assert.Equal(1, line1.Nr);
+        Assert.Equal("Usługa programistyczna — moduł A", line1.Name);
+        Assert.Equal("godz", line1.Unit);
+        Assert.Equal("10", line1.Qty);
+        Assert.Equal("150.00", line1.UnitNetPrice);
+        Assert.Equal("1500.00", line1.NetTotal);
+        Assert.Equal("23", line1.VatRate);
+
+        InvoiceLine line3 = d.Wiersze[2];
+        Assert.Equal(3, line3.Nr);
+        Assert.Equal("zw", line3.VatRate);
+    }
+
+    [Fact]
+    public void ParseInvoice_VatRows_AreCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.NotEmpty(d.VatRows);
+
+        VatRow vat23 = Assert.Single(d.VatRows, v => v.Rate == "23%");
+        Assert.Equal("3900.00", vat23.Net);
+        Assert.Equal("897.00", vat23.Vat);
+
+        VatRow vatZw = Assert.Single(d.VatRows, v => v.Rate == "zw");
+        Assert.Equal("1000.00", vatZw.Net);
+        Assert.Null(vatZw.Vat);
+    }
+
+    [Fact]
+    public void ParseInvoice_Totals_AreCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal("5897.00", d.RazemBrutto);
+    }
+
+    [Fact]
+    public void ParseInvoice_Payment_IsCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal("Przelew", d.FormaPlatnosci);
+        Assert.Single(d.TerminyPlatnosci, "2024-03-29");
+        Assert.NotNull(d.RachunekBankowy);
+        Assert.Equal("12345678901234567890123456", d.RachunekBankowy!.NrRB);
+        Assert.Equal("Bank Testowy S.A.", d.RachunekBankowy.NazwaBanku);
+    }
+
+    [Fact]
+    public void ParseInvoice_AdditionalDescriptions_AreCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Single(d.DodatkowyOpis);
+        Assert.Equal("Zamówienie", d.DodatkowyOpis[0].Klucz);
+        Assert.Equal("ZAM/2024/02/099", d.DodatkowyOpis[0].Wartosc);
+    }
+
+    [Fact]
+    public void ParseInvoice_Registry_IsCorrect()
+    {
+        InvoiceData d = KSeFInvoiceParser.Parse(LoadSampleXml());
+        Assert.Equal(
+            "Testowa Firma Spółka z ograniczoną odpowiedzialnością",
+            d.PelnaNazwa);
+        Assert.Equal("123456789", d.Regon);
+        Assert.Equal("000012345", d.Bdo);
+    }
+
+    [Fact]
+    public void FromXml_KsefReferenceNumber_PassedThroughToData()
+    {
+        // Verify the number survives the Sanitize step and arrives at the generator.
+        // We test via the parser+sanitize pipeline rather than byte-scanning the PDF.
+        string ksefNumber = "1234567890-20240315-TESTTEST-01";
+        InvoiceData parsed = KSeFInvoiceParser.Parse(LoadSampleXml());
+        InvoiceData sanitized = KSeFInvoiceSanitizer.Sanitize(
+            LoadSampleXml(), parsed with { KsefReferenceNumber = ksefNumber });
+        // SanitizeData uses `d with { ... }` and does not touch KsefReferenceNumber,
+        // so it must be preserved unchanged.
+        Assert.Equal(ksefNumber, sanitized.KsefReferenceNumber);
     }
 }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -10,6 +10,7 @@ using CommandLine;
 
 using KSeF.Client.Core.Exceptions;
 using KSeF.Client.Core.Interfaces.Clients;
+using KSeF.Client.Core.Interfaces.Services;
 using KSeF.Client.Core.Models.Authorization;
 using KSeF.Client.Core.Models.Invoices;
 
@@ -531,7 +532,7 @@ public class GuiCommand : IWithConfigCommand
             };
             return Task.FromResult<object>(new
             {
-                invoices = MapInvoicesToJson(_cachedInvoices),
+                invoices = MapInvoicesToJson(_cachedInvoices, _scope?.ServiceProvider.GetService<IVerificationLinkService>()),
                 @params = paramsObj,
             });
         };
@@ -1002,7 +1003,7 @@ public class GuiCommand : IWithConfigCommand
             Log.LogWarning($"Failed to save invoice cache: {ex.Message}");
         }
 
-        return MapInvoicesToJson(allInvoices);
+        return MapInvoicesToJson(allInvoices, _scope?.ServiceProvider.GetService<IVerificationLinkService>());
     }
 
     private string GetProfileCacheKey()
@@ -1754,7 +1755,7 @@ public class GuiCommand : IWithConfigCommand
         return sb.ToString();
     }
 
-    private static object MapInvoicesToJson(List<InvoiceSummary> invoices) =>
+    private static object MapInvoicesToJson(List<InvoiceSummary> invoices, IVerificationLinkService? linkSvc = null) =>
         invoices.Select(i => new
         {
             ksefNumber = i.KsefNumber,
@@ -1767,6 +1768,10 @@ public class GuiCommand : IWithConfigCommand
             netAmount = i.NetAmount,
             vatAmount = i.VatAmount,
             currency = i.Currency,
+            invoiceHash = i.InvoiceHash,
+            ksefVerificationUrl = (linkSvc != null && !string.IsNullOrEmpty(i.InvoiceHash) && !string.IsNullOrEmpty(i.Seller?.Nip))
+                ? linkSvc.BuildInvoiceVerificationUrl(i.Seller!.Nip, i.IssueDate.DateTime, i.InvoiceHash)
+                : null,
         }).ToArray();
 
     private async Task DownloadAsync(DownloadParams dlParams, CancellationToken ct)
@@ -1862,7 +1867,14 @@ public class GuiCommand : IWithConfigCommand
                         await _server.SendEventAsync("invoice_done", new { current = i, file = fileName, pdf = true, progress = n, total = toDownload.Count }).ConfigureAwait(false);
                     }
 
-                    byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme, inv.KsefNumber).ConfigureAwait(false);
+                    string? ksefVerificationUrl = null;
+                    if (!string.IsNullOrEmpty(inv.InvoiceHash) && !string.IsNullOrEmpty(inv.Seller?.Nip))
+                    {
+                        IVerificationLinkService linkSvc = _scope!.ServiceProvider.GetRequiredService<IVerificationLinkService>();
+                        ksefVerificationUrl = linkSvc.BuildInvoiceVerificationUrl(inv.Seller.Nip, inv.IssueDate.DateTime, inv.InvoiceHash);
+                    }
+
+                    byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme, inv.KsefNumber, ksefVerificationUrl).ConfigureAwait(false);
                     string tmpPdf = Path.Combine(workDir, $"{fileName}.pdf");
                     await File.WriteAllBytesAsync(tmpPdf, pdfContent, ct).ConfigureAwait(false);
                     string finalPdf = Path.Combine(outputDir, $"{fileName}.pdf");

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1755,6 +1755,24 @@ public class GuiCommand : IWithConfigCommand
         return sb.ToString();
     }
 
+    private static string? TryBuildVerificationUrl(
+        IVerificationLinkService? linkSvc, string? nip, DateTimeOffset issueDate, string? invoiceHash)
+    {
+        if (linkSvc == null || string.IsNullOrEmpty(nip) || string.IsNullOrEmpty(invoiceHash))
+        {
+            return null;
+        }
+        try
+        {
+            return linkSvc.BuildInvoiceVerificationUrl(nip, issueDate.Date, invoiceHash);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ksef-api] Failed to build verification URL for NIP {nip}: {ex.Message}");
+            return null;
+        }
+    }
+
     private static object MapInvoicesToJson(List<InvoiceSummary> invoices, IVerificationLinkService? linkSvc = null) =>
         invoices.Select(i => new
         {
@@ -1769,9 +1787,7 @@ public class GuiCommand : IWithConfigCommand
             vatAmount = i.VatAmount,
             currency = i.Currency,
             invoiceHash = i.InvoiceHash,
-            ksefVerificationUrl = (linkSvc != null && !string.IsNullOrEmpty(i.InvoiceHash) && !string.IsNullOrEmpty(i.Seller?.Nip))
-                ? linkSvc.BuildInvoiceVerificationUrl(i.Seller!.Nip, i.IssueDate.DateTime, i.InvoiceHash)
-                : null,
+            ksefVerificationUrl = TryBuildVerificationUrl(linkSvc, i.Seller?.Nip, i.IssueDate, i.InvoiceHash),
         }).ToArray();
 
     private async Task DownloadAsync(DownloadParams dlParams, CancellationToken ct)
@@ -1867,12 +1883,8 @@ public class GuiCommand : IWithConfigCommand
                         await _server.SendEventAsync("invoice_done", new { current = i, file = fileName, pdf = true, progress = n, total = toDownload.Count }).ConfigureAwait(false);
                     }
 
-                    string? ksefVerificationUrl = null;
-                    if (!string.IsNullOrEmpty(inv.InvoiceHash) && !string.IsNullOrEmpty(inv.Seller?.Nip))
-                    {
-                        IVerificationLinkService linkSvc = _scope!.ServiceProvider.GetRequiredService<IVerificationLinkService>();
-                        ksefVerificationUrl = linkSvc.BuildInvoiceVerificationUrl(inv.Seller.Nip, inv.IssueDate.DateTime, inv.InvoiceHash);
-                    }
+                    IVerificationLinkService? pdfLinkSvc = _scope?.ServiceProvider.GetService<IVerificationLinkService>();
+                    string? ksefVerificationUrl = TryBuildVerificationUrl(pdfLinkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
 
                     byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme, inv.KsefNumber, ksefVerificationUrl).ConfigureAwait(false);
                     string tmpPdf = Path.Combine(workDir, $"{fileName}.pdf");

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1768,7 +1768,7 @@ public class GuiCommand : IWithConfigCommand
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[ksef-api] Failed to build verification URL for NIP {nip}: {ex.Message}");
+            Log.LogWarning($"[ksef-api] Failed to build verification URL for NIP {nip}: {ex.Message}");
             return null;
         }
     }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1862,7 +1862,7 @@ public class GuiCommand : IWithConfigCommand
                         await _server.SendEventAsync("invoice_done", new { current = i, file = fileName, pdf = true, progress = n, total = toDownload.Count }).ConfigureAwait(false);
                     }
 
-                    byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme).ConfigureAwait(false);
+                    byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme, inv.KsefNumber).ConfigureAwait(false);
                     string tmpPdf = Path.Combine(workDir, $"{fileName}.pdf");
                     await File.WriteAllBytesAsync(tmpPdf, pdfContent, ct).ConfigureAwait(false);
                     string finalPdf = Path.Combine(outputDir, $"{fileName}.pdf");

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1766,7 +1766,17 @@ public class GuiCommand : IWithConfigCommand
         {
             return linkSvc.BuildInvoiceVerificationUrl(nip, issueDate.Date, invoiceHash);
         }
-        catch (Exception ex)
+        catch (ArgumentException ex)
+        {
+            Log.LogWarning($"[ksef-api] Failed to build verification URL for NIP {nip}: {ex.Message}");
+            return null;
+        }
+        catch (FormatException ex)
+        {
+            Log.LogWarning($"[ksef-api] Failed to build verification URL for NIP {nip}: {ex.Message}");
+            return null;
+        }
+        catch (InvalidOperationException ex)
         {
             Log.LogWarning($"[ksef-api] Failed to build verification URL for NIP {nip}: {ex.Message}");
             return null;

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -445,7 +445,7 @@ internal static class KSeFInvoiceSanitizer
         try
         {
             System.Reflection.Assembly asm = typeof(KSeFInvoiceSanitizer).Assembly;
-            using System.IO.Stream? fa3Stream = asm.GetManifestResourceStream("ksefcli.Resources.FA3.xsd");
+            using System.IO.Stream? fa3Stream = asm.GetManifestResourceStream("KSeFCli.Resources.FA3.xsd");
             if (fa3Stream is null)
             {
                 Log.LogWarning("[fa3-validator] FA3.xsd not found in resources; schema validation disabled");
@@ -491,11 +491,11 @@ internal static class KSeFInvoiceSanitizer
         private static readonly Dictionary<string, string> UrlToResource = new(StringComparer.Ordinal)
         {
             ["http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/StrukturyDanych_v10-0E.xsd"]
-                = "ksefcli.Resources.StrukturyDanych.xsd",
+                = "KSeFCli.Resources.StrukturyDanych.xsd",
             ["http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/ElementarneTypyDanych_v10-0E.xsd"]
-                = "ksefcli.Resources.ElementarneTypy.xsd",
+                = "KSeFCli.Resources.ElementarneTypy.xsd",
             ["http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/KodyKrajow_v10-0E.xsd"]
-                = "ksefcli.Resources.KodyKrajow.xsd",
+                = "KSeFCli.Resources.KodyKrajow.xsd",
         };
 
         private readonly System.Reflection.Assembly _asm;

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -902,8 +902,16 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
             return null;
         }
 
-        string url = "https://ksef.mf.gov.pl/r/?p=" + Uri.EscapeDataString(ksefNumber);
-        return QrCodeService.GenerateQrCode(url);
+        try
+        {
+            string url = "https://ksef.mf.gov.pl/r/?p=" + Uri.EscapeDataString(ksefNumber);
+            return QrCodeService.GenerateQrCode(url);
+        }
+        catch (Exception)
+        {
+            // QR generation failure degrades gracefully — ComposeHeader handles null by omitting the QR column.
+            return null;
+        }
     }
 
     private void ComposeHeader(IContainer c, InvoiceData d)
@@ -1609,14 +1617,27 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
 
 public static class KSeFInvoicePdf
 {
+    // KSeF reference numbers follow the pattern NIP-YYYYMMDD-HASH-SEQ; cap at 256 (same as TZnakowy in FA3.xsd).
+    private const int MaxKsefReferenceNumberLength = 256;
+
     public static byte[] FromXml(
         string xmlContent,
         string? colorScheme = null,
         string? ksefReferenceNumber = null)
     {
+        string? normalizedKsefRef = ksefReferenceNumber?.Trim();
+        if (string.IsNullOrEmpty(normalizedKsefRef))
+        {
+            normalizedKsefRef = null;
+        }
+        else if (normalizedKsefRef.Length > MaxKsefReferenceNumberLength)
+        {
+            normalizedKsefRef = normalizedKsefRef[..MaxKsefReferenceNumberLength];
+        }
+
         InvoiceData data = KSeFInvoiceSanitizer.Sanitize(xmlContent, KSeFInvoiceParser.Parse(xmlContent));
         return KSeFInvoicePdfGenerator.Generate(
-            data with { KsefReferenceNumber = ksefReferenceNumber },
+            data with { KsefReferenceNumber = normalizedKsefRef },
             PdfColorScheme.FromName(colorScheme));
     }
 }

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -74,7 +74,10 @@ internal record InvoiceData(
     string? Bdo,
     string? SystemInfo,
     // Not in the XML — injected from API response metadata after parsing
-    string? KsefReferenceNumber
+    string? KsefReferenceNumber,
+    // Pre-computed KSeF verification URL: https://qr.ksef.mf.gov.pl/invoice/{nip}/{dd-MM-yyyy}/{hash}
+    // Built by IVerificationLinkService in the download/search pipeline; null when not available.
+    string? KsefVerificationUrl
 );
 
 // ── Parser ───────────────────────────────────────────────────────────────────
@@ -265,7 +268,8 @@ internal static class KSeFInvoiceParser
             Regon: rejestry is null ? null : Val(rejestry, "REGON"),
             Bdo: rejestry is null ? null : Val(rejestry, "BDO"),
             SystemInfo: Val(naglowek, "SystemInfo"),
-            KsefReferenceNumber: null
+            KsefReferenceNumber: null,
+            KsefVerificationUrl: null
         );
     }
 
@@ -895,17 +899,16 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
 
     // ── Header ───────────────────────────────────────────────────────────────
 
-    private static byte[]? BuildKsefQrPng(string? ksefNumber)
+    private static byte[]? BuildKsefQrPng(string? ksefVerificationUrl)
     {
-        if (string.IsNullOrEmpty(ksefNumber))
+        if (string.IsNullOrEmpty(ksefVerificationUrl))
         {
             return null;
         }
 
         try
         {
-            string url = "https://ksef.mf.gov.pl/r/?p=" + Uri.EscapeDataString(ksefNumber);
-            return QrCodeService.GenerateQrCode(url);
+            return QrCodeService.GenerateQrCode(ksefVerificationUrl);
         }
         catch (Exception)
         {
@@ -916,7 +919,7 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
 
     private void ComposeHeader(IContainer c, InvoiceData d)
     {
-        byte[]? qrPng = BuildKsefQrPng(d.KsefReferenceNumber);
+        byte[]? qrPng = BuildKsefQrPng(d.KsefVerificationUrl);
 
         c.Column(col =>
         {
@@ -1623,7 +1626,8 @@ public static class KSeFInvoicePdf
     public static byte[] FromXml(
         string xmlContent,
         string? colorScheme = null,
-        string? ksefReferenceNumber = null)
+        string? ksefReferenceNumber = null,
+        string? ksefVerificationUrl = null)
     {
         string? normalizedKsefRef = ksefReferenceNumber?.Trim();
         if (string.IsNullOrEmpty(normalizedKsefRef))
@@ -1635,9 +1639,15 @@ public static class KSeFInvoicePdf
             normalizedKsefRef = normalizedKsefRef[..MaxKsefReferenceNumberLength];
         }
 
+        string? normalizedVerificationUrl = ksefVerificationUrl?.Trim();
+        if (string.IsNullOrEmpty(normalizedVerificationUrl))
+        {
+            normalizedVerificationUrl = null;
+        }
+
         InvoiceData data = KSeFInvoiceSanitizer.Sanitize(xmlContent, KSeFInvoiceParser.Parse(xmlContent));
         return KSeFInvoicePdfGenerator.Generate(
-            data with { KsefReferenceNumber = normalizedKsefRef },
+            data with { KsefReferenceNumber = normalizedKsefRef, KsefVerificationUrl = normalizedVerificationUrl },
             PdfColorScheme.FromName(colorScheme));
     }
 }

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -70,7 +70,9 @@ internal record InvoiceData(
     string? PelnaNazwa,
     string? Regon,
     string? Bdo,
-    string? SystemInfo
+    string? SystemInfo,
+    // Not in the XML — injected from API response metadata after parsing
+    string? KsefReferenceNumber
 );
 
 // ── Parser ───────────────────────────────────────────────────────────────────
@@ -260,7 +262,8 @@ internal static class KSeFInvoiceParser
             PelnaNazwa: rejestry is null ? null : Val(rejestry, "PelnaNazwa"),
             Regon: rejestry is null ? null : Val(rejestry, "REGON"),
             Bdo: rejestry is null ? null : Val(rejestry, "BDO"),
-            SystemInfo: Val(naglowek, "SystemInfo")
+            SystemInfo: Val(naglowek, "SystemInfo"),
+            KsefReferenceNumber: null
         );
     }
 
@@ -914,6 +917,14 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                     if (d.RodzajFaktury is not null)
                     {
                         right.Item().Text(InvoiceSubtitle(d.RodzajFaktury)).FontSize(7.5f).FontColor(Gray);
+                    }
+                    if (!string.IsNullOrEmpty(d.KsefReferenceNumber))
+                    {
+                        right.Item().PaddingTop(4).Text(t =>
+                        {
+                            t.Span("Numer KSeF: ").FontSize(7).FontColor(Gray);
+                            t.Span(d.KsefReferenceNumber).FontSize(8).Bold().FontColor(RedAccent);
+                        });
                     }
                 });
             });
@@ -1579,9 +1590,14 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
 
 public static class KSeFInvoicePdf
 {
-    public static byte[] FromXml(string xmlContent, string? colorScheme = null)
+    public static byte[] FromXml(
+        string xmlContent,
+        string? colorScheme = null,
+        string? ksefReferenceNumber = null)
     {
         InvoiceData data = KSeFInvoiceSanitizer.Sanitize(xmlContent, KSeFInvoiceParser.Parse(xmlContent));
-        return KSeFInvoicePdfGenerator.Generate(data, PdfColorScheme.FromName(colorScheme));
+        return KSeFInvoicePdfGenerator.Generate(
+            data with { KsefReferenceNumber = ksefReferenceNumber },
+            PdfColorScheme.FromName(colorScheme));
     }
 }

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -4,6 +4,8 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 
+using KSeF.Client.Api.Services;
+
 using QuestPDF.Fluent;
 using QuestPDF.Helpers;
 using QuestPDF.Infrastructure;
@@ -893,11 +895,24 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
 
     // ── Header ───────────────────────────────────────────────────────────────
 
+    private static byte[]? BuildKsefQrPng(string? ksefNumber)
+    {
+        if (string.IsNullOrEmpty(ksefNumber))
+        {
+            return null;
+        }
+
+        string url = "https://ksef.mf.gov.pl/r/?p=" + Uri.EscapeDataString(ksefNumber);
+        return QrCodeService.GenerateQrCode(url);
+    }
+
     private void ComposeHeader(IContainer c, InvoiceData d)
     {
+        byte[]? qrPng = BuildKsefQrPng(d.KsefReferenceNumber);
+
         c.Column(col =>
         {
-            // Top bar: KSeF branding + invoice number
+            // Top bar: KSeF branding + invoice number (+ optional QR code)
             col.Item().BorderBottom(1.5f).BorderColor(Blue).PaddingBottom(6).Row(row =>
             {
                 row.RelativeItem().Column(left =>
@@ -910,6 +925,10 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                     left.Item().PaddingTop(1).Text(InvoiceSubtitle(d.RodzajFaktury))
                         .FontSize(9).FontColor(Gray);
                 });
+                if (qrPng is not null)
+                {
+                    row.ConstantItem(55).AlignMiddle().Padding(2).Image(qrPng);
+                }
                 row.ConstantItem(210).AlignRight().Column(right =>
                 {
                     right.Item().Text("Numer Faktury:").FontSize(7).FontColor(Gray);

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -480,8 +480,9 @@ internal sealed class WebProgressServer : IDisposable
         }
         else if (path == "/qr" && method == "GET")
         {
-            string? ksefNumber = ctx.Request.QueryString["n"];
-            if (string.IsNullOrWhiteSpace(ksefNumber))
+            const int MaxKsefLength = 200;
+            string? ksefNumber = ctx.Request.QueryString["n"]?.Trim();
+            if (string.IsNullOrEmpty(ksefNumber) || ksefNumber.Length > MaxKsefLength)
             {
                 ctx.Response.StatusCode = 400;
                 ctx.Response.Close();
@@ -675,7 +676,7 @@ tr.has-files:hover>td{background:rgba(46,125,50,.1)}
 .preview-title{text-align:center;font-size:1.1rem;font-weight:700;margin-bottom:.3rem}
 .preview-subtitle{text-align:center;font-size:.8rem;color:#666;margin-bottom:.6rem}
 .preview-qr{text-align:center;margin-bottom:1rem}.preview-qr img{width:90px;height:90px;border:1px solid #ddd;border-radius:4px}
-.preview-qr a{display:inline-block;font-size:.7rem;color:#666;margin-top:.25rem;text-decoration:none}
+.preview-qr a{display:inline-block;font-size:.7rem;color:#666;margin-top:.25rem;text-decoration:none}@media(prefers-color-scheme:dark){.preview-qr a{color:#aaa}}
 .preview-parties{display:flex;gap:1.5rem;margin-bottom:1.2rem}
 .preview-party{flex:1;border:1px solid #ddd;border-radius:6px;padding:.8rem}
 .preview-party h5{font-size:.75rem;text-transform:uppercase;color:#888;margin-bottom:.3rem;letter-spacing:.5px}

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -488,6 +488,14 @@ internal sealed class WebProgressServer : IDisposable
                 ctx.Response.Close();
                 return;
             }
+            if (!Uri.TryCreate(qrUrl, UriKind.Absolute, out Uri? parsedQrUri)
+                || (parsedQrUri.Scheme != Uri.UriSchemeHttp && parsedQrUri.Scheme != Uri.UriSchemeHttps))
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.Close();
+                return;
+            }
+            qrUrl = parsedQrUri.AbsoluteUri;
 
             try
             {
@@ -498,7 +506,11 @@ internal sealed class WebProgressServer : IDisposable
                 ctx.Response.Headers.Add("Cache-Control", "public, max-age=3600");
                 await ctx.Response.OutputStream.WriteAsync(png, ct).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (OperationCanceledException)
+            {
+                Console.Error.WriteLine("[/qr] Request was canceled.");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 Console.Error.WriteLine($"[/qr] QR generation failed: {ex}");
                 ctx.Response.StatusCode = 500;
@@ -539,7 +551,16 @@ internal sealed class WebProgressServer : IDisposable
             ctx.Response.ContentLength64 = body.Length;
             await ctx.Response.OutputStream.WriteAsync(body, ct).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
+        {
+            string errJson = JsonSerializer.Serialize(new { error = "Request was canceled." });
+            byte[] body = Encoding.UTF8.GetBytes(errJson);
+            ctx.Response.ContentType = "application/json; charset=utf-8";
+            ctx.Response.StatusCode = 408;
+            ctx.Response.ContentLength64 = body.Length;
+            await ctx.Response.OutputStream.WriteAsync(body, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             string errJson = JsonSerializer.Serialize(new { error = ex.Message });
             byte[] body = Encoding.UTF8.GetBytes(errJson);
@@ -2531,7 +2552,7 @@ function renderPreview(pop, d, inv) {
     const qrSrc = '/qr?url=' + encodeURIComponent(inv.ksefVerificationUrl);
     html += '<div class="preview-qr">';
     html += '<img src="' + qrSrc + '" alt="QR KSeF" title="Skanuj aby zweryfikowac fakture w KSeF">';
-    html += '<br><a href="' + inv.ksefVerificationUrl + '" target="_blank" rel="noopener">Weryfikuj w KSeF &#8599;</a>';
+    html += '<br><a href="' + escHtml(inv.ksefVerificationUrl) + '" target="_blank" rel="noopener">Weryfikuj w KSeF &#8599;</a>';
     html += '</div>';
   }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -3,6 +3,8 @@ using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 
+using KSeF.Client.Api.Services;
+
 namespace KSeFCli;
 
 internal record SearchParams(string SubjectType, string From, string? To, string DateType, string? Source = null);
@@ -476,6 +478,35 @@ internal sealed class WebProgressServer : IDisposable
                 return JsonSerializer.Serialize(data, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
             }).ConfigureAwait(false);
         }
+        else if (path == "/qr" && method == "GET")
+        {
+            string? ksefNumber = ctx.Request.QueryString["n"];
+            if (string.IsNullOrWhiteSpace(ksefNumber))
+            {
+                ctx.Response.StatusCode = 400;
+                ctx.Response.Close();
+                return;
+            }
+
+            try
+            {
+                string qrUrl = "https://ksef.mf.gov.pl/r/?p=" + Uri.EscapeDataString(ksefNumber);
+                byte[] png = QrCodeService.GenerateQrCode(qrUrl);
+                ctx.Response.ContentType = "image/png";
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentLength64 = png.Length;
+                ctx.Response.Headers.Add("Cache-Control", "public, max-age=3600");
+                await ctx.Response.OutputStream.WriteAsync(png, ct).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                ctx.Response.StatusCode = 500;
+            }
+            finally
+            {
+                ctx.Response.Close();
+            }
+        }
         else if (path == "/quit" && method == "POST")
         {
             ctx.Response.StatusCode = 200;
@@ -642,7 +673,9 @@ tr.has-files>td{background:rgba(46,125,50,.05)}
 tr.has-files:hover>td{background:rgba(46,125,50,.1)}
 .preview-page{padding:2rem;max-width:800px;margin:0 auto;font-size:.85rem;line-height:1.5}
 .preview-title{text-align:center;font-size:1.1rem;font-weight:700;margin-bottom:.3rem}
-.preview-subtitle{text-align:center;font-size:.8rem;color:#666;margin-bottom:1.2rem}
+.preview-subtitle{text-align:center;font-size:.8rem;color:#666;margin-bottom:.6rem}
+.preview-qr{text-align:center;margin-bottom:1rem}.preview-qr img{width:90px;height:90px;border:1px solid #ddd;border-radius:4px}
+.preview-qr a{display:inline-block;font-size:.7rem;color:#666;margin-top:.25rem;text-decoration:none}
 .preview-parties{display:flex;gap:1.5rem;margin-bottom:1.2rem}
 .preview-party{flex:1;border:1px solid #ddd;border-radius:6px;padding:.8rem}
 .preview-party h5{font-size:.75rem;text-transform:uppercase;color:#888;margin-bottom:.3rem;letter-spacing:.5px}
@@ -2492,6 +2525,15 @@ function renderPreview(pop, d, inv) {
   if (d.invoiceType) html += ' | Typ: ' + escHtml(d.invoiceType);
   if (d.currency) html += ' | Waluta: ' + escHtml(d.currency);
   html += '</div>';
+
+  if (inv.ksefNumber) {
+    const qrSrc = '/qr?n=' + encodeURIComponent(inv.ksefNumber);
+    const verifyUrl = 'https://ksef.mf.gov.pl/r/?p=' + encodeURIComponent(inv.ksefNumber);
+    html += '<div class="preview-qr">';
+    html += '<img src="' + qrSrc + '" alt="QR KSeF" title="Skanuj aby zweryfikowac fakture w KSeF">';
+    html += '<br><a href="' + verifyUrl + '" target="_blank" rel="noopener">Weryfikuj w KSeF</a>';
+    html += '</div>';
+  }
 
   html += '<div class="preview-parties">';
   html += '<div class="preview-party"><h5>Sprzedawca</h5>';

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -480,9 +480,9 @@ internal sealed class WebProgressServer : IDisposable
         }
         else if (path == "/qr" && method == "GET")
         {
-            const int MaxKsefLength = 200;
-            string? ksefNumber = ctx.Request.QueryString["n"]?.Trim();
-            if (string.IsNullOrEmpty(ksefNumber) || ksefNumber.Length > MaxKsefLength)
+            const int MaxQrUrlLength = 2048;
+            string? qrUrl = ctx.Request.QueryString["url"]?.Trim();
+            if (string.IsNullOrEmpty(qrUrl) || qrUrl.Length > MaxQrUrlLength)
             {
                 ctx.Response.StatusCode = 400;
                 ctx.Response.Close();
@@ -491,7 +491,6 @@ internal sealed class WebProgressServer : IDisposable
 
             try
             {
-                string qrUrl = "https://ksef.mf.gov.pl/r/?p=" + Uri.EscapeDataString(ksefNumber);
                 byte[] png = QrCodeService.GenerateQrCode(qrUrl);
                 ctx.Response.ContentType = "image/png";
                 ctx.Response.StatusCode = 200;
@@ -499,8 +498,9 @@ internal sealed class WebProgressServer : IDisposable
                 ctx.Response.Headers.Add("Cache-Control", "public, max-age=3600");
                 await ctx.Response.OutputStream.WriteAsync(png, ct).ConfigureAwait(false);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Console.Error.WriteLine($"[/qr] QR generation failed: {ex}");
                 ctx.Response.StatusCode = 500;
             }
             finally
@@ -676,7 +676,7 @@ tr.has-files:hover>td{background:rgba(46,125,50,.1)}
 .preview-title{text-align:center;font-size:1.1rem;font-weight:700;margin-bottom:.3rem}
 .preview-subtitle{text-align:center;font-size:.8rem;color:#666;margin-bottom:.6rem}
 .preview-qr{text-align:center;margin-bottom:1rem}.preview-qr img{width:90px;height:90px;border:1px solid #ddd;border-radius:4px}
-.preview-qr a{display:inline-block;font-size:.7rem;color:#666;margin-top:.25rem;text-decoration:none}@media(prefers-color-scheme:dark){.preview-qr a{color:#aaa}}
+.preview-qr a{display:inline-flex;align-items:center;gap:.25rem;font-size:.72rem;color:#1565c0;margin-top:.4rem;text-decoration:none;border:1px solid #1565c0;border-radius:4px;padding:.2rem .5rem;transition:background .15s,color .15s}.preview-qr a:hover{background:#1565c0;color:#fff}@media(prefers-color-scheme:dark){.preview-qr a{color:#90caf9;border-color:#90caf9}.preview-qr a:hover{background:#90caf9;color:#000}}
 .preview-parties{display:flex;gap:1.5rem;margin-bottom:1.2rem}
 .preview-party{flex:1;border:1px solid #ddd;border-radius:6px;padding:.8rem}
 .preview-party h5{font-size:.75rem;text-transform:uppercase;color:#888;margin-bottom:.3rem;letter-spacing:.5px}
@@ -2527,12 +2527,11 @@ function renderPreview(pop, d, inv) {
   if (d.currency) html += ' | Waluta: ' + escHtml(d.currency);
   html += '</div>';
 
-  if (inv.ksefNumber) {
-    const qrSrc = '/qr?n=' + encodeURIComponent(inv.ksefNumber);
-    const verifyUrl = 'https://ksef.mf.gov.pl/r/?p=' + encodeURIComponent(inv.ksefNumber);
+  if (inv.ksefVerificationUrl) {
+    const qrSrc = '/qr?url=' + encodeURIComponent(inv.ksefVerificationUrl);
     html += '<div class="preview-qr">';
     html += '<img src="' + qrSrc + '" alt="QR KSeF" title="Skanuj aby zweryfikowac fakture w KSeF">';
-    html += '<br><a href="' + verifyUrl + '" target="_blank" rel="noopener">Weryfikuj w KSeF</a>';
+    html += '<br><a href="' + inv.ksefVerificationUrl + '" target="_blank" rel="noopener">Weryfikuj w KSeF &#8599;</a>';
     html += '</div>';
   }
 

--- a/src/KSeFCli/XML2PDFCommand.cs
+++ b/src/KSeFCli/XML2PDFCommand.cs
@@ -54,14 +54,16 @@ public class XML2PDFCommand : IGlobalCommand
         return 0;
     }
 
-    public static Task<byte[]> XML2PDF(string xmlContent, bool quiet, CancellationToken cancellationToken, string? colorScheme = null)
+    public static Task<byte[]> XML2PDF(
+        string xmlContent, bool quiet, CancellationToken cancellationToken,
+        string? colorScheme = null, string? ksefReferenceNumber = null)
     {
         if (!quiet)
         {
             Console.WriteLine("Generating PDF (native renderer)...");
         }
 
-        return Task.FromResult(KSeFInvoicePdf.FromXml(xmlContent, colorScheme));
+        return Task.FromResult(KSeFInvoicePdf.FromXml(xmlContent, colorScheme, ksefReferenceNumber));
     }
 
     public static void AssertPdfGeneratorAvailable()

--- a/src/KSeFCli/XML2PDFCommand.cs
+++ b/src/KSeFCli/XML2PDFCommand.cs
@@ -56,14 +56,14 @@ public class XML2PDFCommand : IGlobalCommand
 
     public static Task<byte[]> XML2PDF(
         string xmlContent, bool quiet, CancellationToken cancellationToken,
-        string? colorScheme = null, string? ksefReferenceNumber = null)
+        string? colorScheme = null, string? ksefReferenceNumber = null, string? ksefVerificationUrl = null)
     {
         if (!quiet)
         {
             Console.WriteLine("Generating PDF (native renderer)...");
         }
 
-        return Task.FromResult(KSeFInvoicePdf.FromXml(xmlContent, colorScheme, ksefReferenceNumber));
+        return Task.FromResult(KSeFInvoicePdf.FromXml(xmlContent, colorScheme, ksefReferenceNumber, ksefVerificationUrl));
     }
 
     public static void AssertPdfGeneratorAvailable()


### PR DESCRIPTION
Displays KSeF reference numbers prominently in generated invoice PDFs when available from API responses

Extends PDF generation to accept reference numbers as parameter and renders them with red accent styling in document header

Documents all supported invoice fields extracted from XML schema in bilingual reference tables

Expands test coverage with comprehensive field validation and parsing verification across all invoice sections


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PDFs and invoice previews can include KSeF reference numbers and a verification QR/link; previews/details updated and a server endpoint serves QR images.
* **Documentation**
  * Added Polish and English sections mapping FA(3) fields to PDF output (header, invoice, parties, lines, payments, registry).
* **Tests**
  * Expanded PDF generation and parser tests covering headers, parties, line items, totals, payments, and KSeF reference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->