### PR TITLE
fix: sync active profile cache with background refresh

### DIFF
--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1143,9 +1143,15 @@ public class GuiCommand : IWithConfigCommand
         int newCount = invoices.Count(i => !prevKeys.Contains(i.KsefNumber));
         Log.LogInformation($"[bg-refresh] Profile '{name}': {invoices.Count} invoices, {newCount} new");
 
-        // Do not send SSE for the active profile: JS silentRefresh() handles the UI update.
-        // Sending it would cause double browser notifications (SSE + silentRefresh detection).
-        if (_server != null && !isActiveProfile)
+        // For the active profile, update the in-memory cache so the browser sees fresh data
+        // via /cached-invoices without needing a separate /search round-trip.
+        if (isActiveProfile)
+        {
+            _cachedInvoices = invoices;
+            _lastSearchParams = sp;
+        }
+
+        if (_server != null)
         {
             await _server.SendEventAsync("background_refresh", new
             {

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2028,6 +2028,11 @@ function connectSSE() {
       }
       case 'background_refresh':
         // d = { profileName, count, newCount }
+        if (d.profileName === currentSessionProfile) {
+          // Active profile: C# bg-refresh already updated _cachedInvoices in-memory.
+          // Reload the table so the screen matches the logs without a manual search.
+          loadCachedInvoices();
+        }
         if (d.newCount > 0) {
           markProfileBadge(d.profileName, d.newCount);
           notifyNewInvoices(d.profileName, d.newCount);
@@ -2473,6 +2478,8 @@ document.addEventListener('keydown', (e) => {
 
 async function showDetails(idx, event) {
   closeDetails();
+  const inv = invoices.find(i => i._idx === idx) || {};
+  const cacheKey = inv.ksefNumber || ('idx-' + idx);
 
   const overlay = document.createElement('div');
   overlay.className = 'detail-overlay';
@@ -2486,12 +2493,12 @@ async function showDetails(idx, event) {
   detailOverlay = overlay;
 
   try {
-    let data = detailCache[idx];
+    let data = detailCache[cacheKey];
     if (!data) {
       const res = await fetch('/invoice-details?idx=' + idx);
       if (!res.ok) { const e = await res.json(); throw new Error(e.error || 'Failed'); }
       data = await res.json();
-      detailCache[idx] = data;
+      detailCache[cacheKey] = data;
     }
     if (detailOverlay !== overlay) return; // closed while fetching
     renderDetails(pop, data);
@@ -2571,13 +2578,14 @@ async function showPreview(idx) {
   document.body.appendChild(overlay);
   detailOverlay = overlay;
 
+  const cacheKey = inv.ksefNumber || ('idx-' + idx);
   try {
-    let data = detailCache[idx];
+    let data = detailCache[cacheKey];
     if (!data) {
       const res = await fetch('/invoice-details?idx=' + idx);
       if (!res.ok) { const e = await res.json(); throw new Error(e.error || 'Failed'); }
       data = await res.json();
-      detailCache[idx] = data;
+      detailCache[cacheKey] = data;
     }
     if (detailOverlay !== overlay) return;
     renderPreview(pop, data, inv);


### PR DESCRIPTION
- Update in-memory cache when active profile refreshes in background
- Use invoice numbers instead of indices for detail caching
- Send SSE events for all profiles to trigger UI updates
- Reload cached invoices automatically for active profile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed active profile cache refresh to properly update in-memory data and send notifications.
  
* **Improvements**
  * Invoice UI now automatically refreshes when the active profile updates in the background.
  * Enhanced invoice detail caching mechanism for more reliable data persistence across profile refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->