### PR TITLE
feat: handle KSeF API 10k result limit with warnings

### DIFF
--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -911,8 +911,11 @@ public class GuiCommand : IWithConfigCommand
         };
     }
 
-    /// <summary>Pages through the KSeF API and returns all invoice summaries matching the filters.</summary>
-    private static async Task<List<InvoiceSummary>> FetchAllPagesAsync(
+    /// <summary>Pages through the KSeF API and returns all invoice summaries matching the filters.
+    /// The KSeF API enforces a hard limit of 10 000 results per query. If this limit is reached
+    /// (<c>IsTruncated == true</c>), the method returns partial results and sets
+    /// <c>WasTruncated</c> to <see langword="true"/> so callers can warn the user.</summary>
+    private static async Task<(List<InvoiceSummary> Invoices, bool WasTruncated)> FetchAllPagesAsync(
         IKSeFClient client,
         InvoiceQueryFilters filters,
         string accessToken,
@@ -925,9 +928,16 @@ public class GuiCommand : IWithConfigCommand
         const int pageSize = 100;
         const int maxRetries = 5;
         const int interPageDelayMs = 200;
+        const int maxApiOffset = 10_000;
 
         do
         {
+            if (currentOffset >= maxApiOffset)
+            {
+                Log.LogWarning($"Reached KSeF API offset limit ({maxApiOffset}). Returning {all.Count} partial results.");
+                return (all, true);
+            }
+
             Log.LogInformation($"Fetching page with offset {currentOffset} and size {pageSize}");
             for (int attempt = 0; ; attempt++)
             {
@@ -954,6 +964,12 @@ public class GuiCommand : IWithConfigCommand
                 all.AddRange(pagedResponse.Invoices);
             }
 
+            if (pagedResponse.IsTruncated)
+            {
+                Log.LogWarning($"KSeF API returned IsTruncated=true at offset {currentOffset}. Total results exceed 10 000. Returning {all.Count} partial results.");
+                return (all, true);
+            }
+
             currentOffset += pageSize;
 
             if (pagedResponse.HasMore == true)
@@ -962,7 +978,7 @@ public class GuiCommand : IWithConfigCommand
             }
         } while (pagedResponse.HasMore == true);
 
-        return all;
+        return (all, false);
     }
 
     private async Task<object> SearchAsync(SearchParams searchParams, CancellationToken ct)
@@ -975,11 +991,11 @@ public class GuiCommand : IWithConfigCommand
 
         InvoiceQueryFilters filters = await BuildFiltersAsync(searchParams, ct).ConfigureAwait(false);
         string accessToken = await GetAccessToken(_scope!, ct).ConfigureAwait(false);
-        List<InvoiceSummary> allInvoices = await FetchAllPagesAsync(_ksefClient!, filters, accessToken, ct).ConfigureAwait(false);
+        (List<InvoiceSummary> allInvoices, bool wasTruncated) = await FetchAllPagesAsync(_ksefClient!, filters, accessToken, ct).ConfigureAwait(false);
 
         Log.LogInformation(isCyclic
-            ? $"[ksef-api] cyclic-search done — {allInvoices.Count} invoices"
-            : $"[ksef-api] search done — {allInvoices.Count} invoices");
+            ? $"[ksef-api] cyclic-search done — {allInvoices.Count} invoices{(wasTruncated ? " (TRUNCATED — KSeF 10K limit)" : "")}"
+            : $"[ksef-api] search done — {allInvoices.Count} invoices{(wasTruncated ? " (TRUNCATED — KSeF 10K limit)" : "")}");
         _cachedInvoices = allInvoices;
         // Cyclic searches keep the last manual params intact — only the invoice list is refreshed.
         if (!isCyclic)
@@ -1004,7 +1020,11 @@ public class GuiCommand : IWithConfigCommand
             Log.LogWarning($"Failed to save invoice cache: {ex.Message}");
         }
 
-        return MapInvoicesToJson(allInvoices, _scope?.ServiceProvider.GetService<IVerificationLinkService>());
+        return new
+        {
+            invoices = MapInvoicesToJson(allInvoices, _scope?.ServiceProvider.GetService<IVerificationLinkService>()),
+            truncated = wasTruncated,
+        };
     }
 
     private string GetProfileCacheKey()
@@ -1108,9 +1128,10 @@ public class GuiCommand : IWithConfigCommand
 
         IKSeFClient client = scope.ServiceProvider.GetRequiredService<IKSeFClient>();
         List<InvoiceSummary> invoices;
+        bool wasTruncated;
         try
         {
-            invoices = await FetchAllPagesAsync(client, filters, accessToken, ct, abortOn429: true).ConfigureAwait(false);
+            (invoices, wasTruncated) = await FetchAllPagesAsync(client, filters, accessToken, ct, abortOn429: true).ConfigureAwait(false);
             // Suggestion 1: invalidate the stored access token after every successful fetch.
             // KSeF revokes access tokens as soon as the search session completes, so ValidUntil
             // (~2 h) is misleading. Expiring it here ensures the next cycle does a TokenRefresh
@@ -1124,8 +1145,13 @@ public class GuiCommand : IWithConfigCommand
             ExpireStoredAccessToken(name, profile);
             // GetAccessTokenForProfile sees the expired access token and performs TokenRefresh.
             string freshToken = await GetAccessTokenForProfile(name, profile, scope, ct).ConfigureAwait(false);
-            invoices = await FetchAllPagesAsync(client, filters, freshToken, ct, abortOn429: true).ConfigureAwait(false);
+            (invoices, wasTruncated) = await FetchAllPagesAsync(client, filters, freshToken, ct, abortOn429: true).ConfigureAwait(false);
             ExpireStoredAccessToken(name, profile);
+        }
+
+        if (wasTruncated)
+        {
+            Log.LogWarning($"[bg-refresh] Profile '{name}': results truncated at KSeF 10K limit — narrowing the date range may help");
         }
 
         if (prev == null)
@@ -1141,7 +1167,7 @@ public class GuiCommand : IWithConfigCommand
         }
 
         int newCount = invoices.Count(i => !prevKeys.Contains(i.KsefNumber));
-        Log.LogInformation($"[bg-refresh] Profile '{name}': {invoices.Count} invoices, {newCount} new");
+        Log.LogInformation($"[bg-refresh] Profile '{name}': {invoices.Count} invoices, {newCount} new{(wasTruncated ? " (TRUNCATED)" : "")}");
 
         // For the active profile, update the in-memory cache so the browser sees fresh data
         // via /cached-invoices without needing a separate /search round-trip.
@@ -1158,6 +1184,7 @@ public class GuiCommand : IWithConfigCommand
                 profileName = name,
                 count = invoices.Count,
                 newCount,
+                truncated = wasTruncated,
             }).ConfigureAwait(false);
         }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2027,11 +2027,14 @@ function connectSSE() {
         break;
       }
       case 'background_refresh':
-        // d = { profileName, count, newCount }
+        // d = { profileName, count, newCount, truncated }
         if (d.profileName === currentSessionProfile) {
           // Active profile: C# bg-refresh already updated _cachedInvoices in-memory.
           // Reload the table so the screen matches the logs without a manual search.
           loadCachedInvoices();
+          if (d.truncated) {
+            setStatus('\u26A0\uFE0F Wyniki obci\u0119te \u2014 KSeF zwraca maks. 10\u00A0000 faktur. Zaw\u0119\u017C zakres dat.', 'error');
+          }
         }
         if (d.newCount > 0) {
           markProfileBadge(d.profileName, d.newCount);
@@ -2164,11 +2167,16 @@ async function doSearch() {
     const res = await fetch('/search', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(params) });
     if (!res.ok) { const e = await res.json(); throw new Error(e.error || 'Search failed'); }
     if (profileSwitchGen !== myGen) { searchRunning = false; return; } // profile switched — discard
-    invoices = await res.json();
+    const searchResult = await res.json();
+    invoices = searchResult.invoices;
     for (let i = 0; i < invoices.length; i++) invoices[i]._idx = i;
     total = invoices.length;
     countLabel.textContent = total + ' faktur';
-    setStatus('Znaleziono ' + total + ' faktur.', total > 0 ? 'info' : 'idle');
+    if (searchResult.truncated) {
+      setStatus('\u26A0\uFE0F Wyniki obci\u0119te \u2014 KSeF zwraca maks. 10\u00A0000 faktur. Zaw\u0119\u017A zakres dat.', 'error');
+    } else {
+      setStatus('Znaleziono ' + total + ' faktur.', total > 0 ? 'info' : 'idle');
+    }
     buildCurrencyFilter();
     displayAll = false;
     currentPage = 0;
@@ -2228,14 +2236,18 @@ async function silentRefresh() {
     };
     const res = await fetch('/search', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(params) });
     if (!res.ok) { await fetchTokenStatus(); return; }
-    const fresh = await res.json();
+    const searchResult = await res.json();
     if (profileSwitchGen !== myGen) return; // profile switched while request was in-flight — discard
+    const fresh = searchResult.invoices;
     fresh.forEach((inv, i) => inv._idx = i);
-    console.info('[auto-refresh] Cyclic search complete —', fresh.length, 'invoices');
+    console.info('[auto-refresh] Cyclic search complete —', fresh.length, 'invoices', searchResult.truncated ? '(TRUNCATED)' : '');
     detectNewInvoices(fresh);
     invoices = fresh;
     total = invoices.length;
     countLabel.textContent = total + ' faktur';
+    if (searchResult.truncated) {
+      setStatus('\u26A0\uFE0F Wyniki obci\u0119te \u2014 KSeF zwraca maks. 10\u00A0000 faktur. Zaw\u0119\u017C zakres dat.', 'error');
+    }
     buildCurrencyFilter();
     renderTable();
     checkExisting();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2031,10 +2031,12 @@ function connectSSE() {
         if (d.profileName === currentSessionProfile) {
           // Active profile: C# bg-refresh already updated _cachedInvoices in-memory.
           // Reload the table so the screen matches the logs without a manual search.
-          loadCachedInvoices();
-          if (d.truncated) {
-            setStatus('\u26A0\uFE0F Wyniki obci\u0119te \u2014 KSeF zwraca maks. 10\u00A0000 faktur. Zaw\u0119\u017C zakres dat.', 'error');
-          }
+          // Must await before setting truncation status — loadCachedInvoices calls setStatus on completion.
+          loadCachedInvoices().then(() => {
+            if (d.truncated) {
+              setStatus('\u26A0\uFE0F Wyniki obci\u0119te \u2014 KSeF zwraca maks. 10\u00A0000 faktur. Zaw\u0119\u017C zakres dat.', 'error');
+            }
+          });
         }
         if (d.newCount > 0) {
           markProfileBadge(d.profileName, d.newCount);
@@ -2247,6 +2249,8 @@ async function silentRefresh() {
     countLabel.textContent = total + ' faktur';
     if (searchResult.truncated) {
       setStatus('\u26A0\uFE0F Wyniki obci\u0119te \u2014 KSeF zwraca maks. 10\u00A0000 faktur. Zaw\u0119\u017C zakres dat.', 'error');
+    } else {
+      setStatus('Auto-od\u015Bwie\u017Canie: ' + total + ' faktur.', 'idle');
     }
     buildCurrencyFilter();
     renderTable();


### PR DESCRIPTION
The KSeF API enforces a hard limit of 10,000 results per query. This change detects when results are truncated and warns users to narrow their date ranges.

- Return truncation status alongside invoice results
- Display warning messages in web interface when limit reached
- Log truncation events in background refresh operations
- Update search response format to include truncation flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects when invoice search results are truncated at KSeF's 10,000-item limit and notifies users with a clear warning.
  * Background refresh now reports truncation and logs a truncation indicator.

* **User Interface**
  * Search and refresh responses now include a truncation flag so the UI can show an explicit "(TRUNCATED)" status and guide users to refine their query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->