### PR TITLE
chore: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -47,12 +47,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -66,7 +66,7 @@ jobs:
         run: dotnet test src/KSeFCli.Tests/KSeFCli.Tests.csproj -c Release --no-build --logger trx
 
       - name: Publish test results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v2
         if: always()
         with:
           name: Test results (${{ matrix.os }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,13 +50,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get release metadata
         id: meta
@@ -147,6 +147,15 @@ jobs:
             ```bash
             chmod +x ksefcli-linux-x64   # or ksefcli-osx-arm64, etc.
             ```
+
+            ## Docker image (GitHub Container Registry)
+
+            ```bash
+            docker pull ghcr.io/${{ github.repository_owner }}/ksefcli:${{ steps.meta.outputs.tag }}
+            docker pull ghcr.io/${{ github.repository_owner }}/ksefcli:latest
+            ```
+
+            Image page: https://github.com/${{ github.repository }}/pkgs/container/ksefcli
           files: |
             dist/ksefcli-linux-x64
             dist/ksefcli-linux-arm64
@@ -164,7 +173,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -173,7 +182,7 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
         run: |
@@ -210,7 +219,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -219,11 +228,11 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/ksefcli
           tags: |
@@ -238,7 +247,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to GHCR
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 | 🌐 **GUI w przeglądarce** | Interfejs lokalny dostępny bez instalacji                                                 |
 | 📄 **Eksport PDF**        | Natywny renderer (QuestPDF) — bez Node.js, git ani zewnętrznych narzędzi                  |
 | 📊 **Podsumowanie CSV**   | Zestawienie faktur za wybrany miesiąc — gotowy plik CSV (UTF-8 BOM, separator `;`)        |
+| 📈 **Wykres przychodów**  | Poziomy wykres słupkowy sum netto per waluta — widoczny przy liście faktur (opt-out)      |
 | 🔄 **Auto-odświeżanie**   | Wyszukiwanie w tle co N minut; powiadomienia o nowych fakturach                           |
 | 🔔 **Powiadomienia**      | Powiadomienia OS, webhooki Slack / Teams oraz e-mail (SMTP) per profil                    |
 | 💾 **Cache SQLite**       | Wyniki wyszukiwania przechowywane lokalnie; przełączanie profili bez ponownego pobierania |
@@ -185,6 +186,20 @@ Na końcu pliku dodawane są sumy brutto pogrupowane według waluty.
 **Nazwa pliku:** `summary-RRRR-MM.csv` w wybranym katalogu wyjściowym. Jeśli opcja **Oddziel katalogi po NIPie** jest włączona, plik trafia do podkatalogu z NIP-em — tak samo jak pobrane faktury.
 
 > Podsumowanie generowane jest z danych w lokalnym cache — nie wymaga dodatkowego połączenia z KSeF.
+
+### 📈 Wykres przychodów
+
+Po wyszukaniu faktur panel filtrowania walut wyświetla poziomy wykres słupkowy z sumami netto per waluta. Wykres jest widoczny automatycznie gdy lista faktur zawiera dane; można go wyłączyć w **Preferencjach** (checkbox **Pokaż wykres przychodów**).
+
+Kwoty wyświetlane są w formacie polskim (np. `1 234 567,89`). Słupki posortowane są malejąco według wartości.
+
+> Wykres generowany jest z danych w lokalnym cache — nie wymaga połączenia z KSeF.
+
+### ⚠️ Limit 10 000 wyników API KSeF
+
+KSeF API ogranicza wyniki zapytania do **10 000 faktur** w jednym zakresie dat. Jeśli ten limit zostanie osiągnięty, aplikacja wyświetla ostrzeżenie i zwraca dotychczas pobrane faktury — bez przerywania działania.
+
+Aby pobrać pełne dane w przypadku dużej liczby faktur, **zawęź zakres dat** (np. wyszukuj miesiąc po miesiącu).
 
 ### 🔔 Powiadomienia
 
@@ -389,6 +404,7 @@ Pola wyodrębniane z XML faktury KSeF (schemat FA(3)) i uwzględniane w generowa
 | 🌐 **Browser GUI**         | Local interface, no installation needed                                                     |
 | 📄 **PDF export**          | Native renderer (QuestPDF) — no Node.js, git, or external tools                             |
 | 📊 **Monthly CSV summary** | One-click invoice summary for a selected month — Excel-ready CSV (UTF-8 BOM, `;` separator) |
+| 📈 **Income chart**        | Horizontal bar chart of net totals by currency, shown alongside the invoice list (opt-out)  |
 | 🔄 **Auto-refresh**        | Background search every N minutes; OS notifications for new invoices                        |
 | 🔔 **Notifications**       | OS desktop notifications, Slack / Teams webhooks, and e-mail (SMTP) per profile             |
 | 💾 **SQLite cache**        | Search results stored locally; profile switching without re-fetching                        |
@@ -540,6 +556,20 @@ A per-currency gross total is appended at the end of the file.
 **File name:** `summary-YYYY-MM.csv` in the configured output directory. If the **Separate directories by NIP** option is enabled, the file is placed in the NIP subdirectory — the same path as downloaded invoices.
 
 > The summary is generated from the local cache — no additional KSeF connection is required.
+
+### 📈 Income chart
+
+After searching, the currency filter panel displays a horizontal bar chart of net totals per currency. The chart appears automatically when invoice data is available; it can be disabled in **Preferences** (the **Show income chart** checkbox).
+
+Amounts are formatted using Polish locale conventions (e.g. `1 234 567,89`). Bars are sorted descending by value.
+
+> The chart is generated from the local cache — no KSeF connection required.
+
+### ⚠️ KSeF API 10,000-result limit
+
+The KSeF API limits query results to **10,000 invoices** per date range. If this limit is reached, the app displays a warning and returns the invoices fetched so far — without interrupting operation.
+
+To retrieve complete data when dealing with a large invoice volume, **narrow the date range** (e.g. search month by month).
 
 ### 🔔 Notifications
 


### PR DESCRIPTION
- Upgrade checkout, setup-dotnet, buildx, metadata, and build-push actions
- Add Docker/GHCR pull instructions to release notes
- Document income chart feature and KSeF 10k result limit in README
