### PR TITLE
fix: handle KSeF error 21405 and improve error UX

### DIFF
--- a/src/KSeFCli.Tests/WebProgressServerTests.cs
+++ b/src/KSeFCli.Tests/WebProgressServerTests.cs
@@ -413,7 +413,8 @@ public class WebProgressServerTests : IDisposable
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         string json = await response.Content.ReadAsStringAsync();
         Assert.Contains("error", json);
-        Assert.Contains("Test error", json); // error message is included to aid user bug reports
+        Assert.Contains("Internal server error", json); // generic fallback — raw message is not exposed
+        Assert.DoesNotContain("Test error", json); // internal detail must not leak for non-KSeF exceptions
         cts.Cancel();
     }
 

--- a/src/KSeFCli.Tests/WebProgressServerTests.cs
+++ b/src/KSeFCli.Tests/WebProgressServerTests.cs
@@ -413,7 +413,7 @@ public class WebProgressServerTests : IDisposable
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         string json = await response.Content.ReadAsStringAsync();
         Assert.Contains("error", json);
-        Assert.DoesNotContain("Test error", json); // internal message must not leak to client
+        Assert.Contains("Test error", json); // error message is included to aid user bug reports
         cts.Cancel();
     }
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -954,6 +954,14 @@ public class GuiCommand : IWithConfigCommand
                         cancellationToken: ct).ConfigureAwait(false);
                     break;
                 }
+                catch (KsefApiException ex) when (
+                    (ex.ErrorResponse?.Exception?.ExceptionDetailList != null &&
+                     ex.ErrorResponse.Exception.ExceptionDetailList.Any(d => d.ExceptionCode == 21405)) ||
+                    ex.Message.Contains("21405", StringComparison.Ordinal))
+                {
+                    Log.LogWarning($"KSeF API rejected offset limit (21405) at offset {currentOffset}. Returning {all.Count} partial results.");
+                    return (all, true);
+                }
                 catch (KsefRateLimitException ex) when (attempt < maxRetries && !abortOn429)
                 {
                     TimeSpan delay = ex.RecommendedDelay + TimeSpan.FromSeconds(attempt * 2);

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 
 using KSeF.Client.Api.Services;
+using KSeF.Client.Core.Exceptions;
 
 namespace KSeFCli;
 
@@ -585,11 +586,12 @@ internal sealed class WebProgressServer : IDisposable
             Console.Error.WriteLine($"[HandleAction] Unhandled exception: {ex}");
             (int statusCode, string errorMessage) = ex switch
             {
-                ArgumentException or FormatException or JsonException => (400, "Bad Request"),
-                UnauthorizedAccessException => (401, "Unauthorized"),
-                FileNotFoundException or DirectoryNotFoundException => (404, "Not Found"),
-                HttpRequestException => (502, "Bad Gateway"),
-                _ => (500, "Internal Server Error"),
+                KsefApiException kex => ((int)kex.StatusCode, kex.Message),
+                ArgumentException or FormatException or JsonException => (400, ex.Message),
+                UnauthorizedAccessException => (401, ex.Message),
+                FileNotFoundException or DirectoryNotFoundException => (404, ex.Message),
+                HttpRequestException => (502, ex.Message),
+                _ => (500, ex.Message),
             };
             string errJson = JsonSerializer.Serialize(new { error = errorMessage });
             byte[] body = Encoding.UTF8.GetBytes(errJson);
@@ -2335,7 +2337,7 @@ async function doSearch() {
     knownInvoiceKsefNumbers = new Set(invoices.map(i => i.ksefNumber));
   } catch (err) {
     searchRunning = false;
-    setStatus('Blad: ' + err.message, 'error');
+    setStatus('Błąd wyszukiwania: ' + err.message, 'error');
     updateAuthButton();
   }
 }
@@ -2380,7 +2382,7 @@ async function silentRefresh() {
       source: 'auto'
     };
     const res = await fetch('/search', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(params) });
-    if (!res.ok) { await fetchTokenStatus(); return; }
+    if (!res.ok) { try { const e = await res.json(); setStatus('Auto-odświeżanie: błąd — ' + (e.error || 'HTTP ' + res.status), 'error'); } catch(_) { setStatus('Auto-odświeżanie: błąd HTTP ' + res.status, 'error'); } await fetchTokenStatus(); return; }
     const searchResult = await res.json();
     if (profileSwitchGen !== myGen) return; // profile switched while request was in-flight — discard
     const fresh = searchResult.invoices;

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -588,10 +588,10 @@ internal sealed class WebProgressServer : IDisposable
             {
                 KsefApiException kex => ((int)kex.StatusCode, kex.Message),
                 ArgumentException or FormatException or JsonException => (400, ex.Message),
-                UnauthorizedAccessException => (401, ex.Message),
-                FileNotFoundException or DirectoryNotFoundException => (404, ex.Message),
-                HttpRequestException => (502, ex.Message),
-                _ => (500, ex.Message),
+                UnauthorizedAccessException => (401, "Unauthorized"),
+                FileNotFoundException or DirectoryNotFoundException => (404, "Not found"),
+                HttpRequestException => (502, "Upstream service error"),
+                _ => (500, "Internal server error"),
             };
             string errJson = JsonSerializer.Serialize(new { error = errorMessage });
             byte[] body = Encoding.UTF8.GetBytes(errJson);
@@ -2401,8 +2401,10 @@ async function silentRefresh() {
     renderTable();
     checkExisting();
     await fetchTokenStatus();
-  } catch(e) { /* silent — do not disrupt user */ }
-  finally { refreshRunning = false; }
+  } catch(e) {
+    setStatus('Auto-odświeżanie: błąd sieci — ' + e.message, 'error');
+    await fetchTokenStatus();
+  } finally { refreshRunning = false; }
 }
 
 function detectNewInvoices(fresh) {


### PR DESCRIPTION
- Gracefully handle API error code 21405 (offset limit exceeded) by returning partial results instead of failing
- Surface actual API error messages to the client instead of generic HTTP labels
- Fix auto-refresh to show meaningful error messages when requests fail
- Polish search error message text (encoding fix + clearer wording)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of data fetch limits by returning partial results when API boundaries are reached, instead of complete failure.
  * Enhanced error messages throughout the application to provide clearer, more descriptive feedback about issues.
  * Better error recovery during automatic token refresh with improved error reporting and JSON parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->