### PR TITLE
refactor: rename offset variable to page number

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@
 #
 # Output: dist/ksefcli-<target>  (or dist/ksefcli-<target>.exe on Windows)
 # Requires: .NET SDK 10+
-
+#
 set -euo pipefail
 
 TARGETS=(linux-x64 linux-arm64 win-x64 osx-x64 osx-arm64)

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -927,21 +927,22 @@ public class GuiCommand : IWithConfigCommand
     {
         List<InvoiceSummary> all = new();
         PagedInvoiceResponse pagedResponse;
-        int currentOffset = 0;
+        int currentPage = 0;        // page number (0-based) — pageOffset in the API is a page number, not a record offset
         const int pageSize = 100;
         const int maxRetries = 5;
         const int interPageDelayMs = 200;
-        const int maxApiOffset = 10_000;
+        const int maxApiOffset = 10_000;  // KSeF hard limit: pageOffset * pageSize must be < 10 000
 
         do
         {
-            if (currentOffset >= maxApiOffset)
+            // Guard: page 100 × pageSize 100 = 10 000 records — the API rejects this with 21405.
+            if (currentPage * pageSize >= maxApiOffset)
             {
-                Log.LogWarning($"Reached KSeF API offset limit ({maxApiOffset}). Returning {all.Count} partial results.");
+                Log.LogWarning($"Reached KSeF API offset limit (page {currentPage}, record {currentPage * pageSize}). Returning {all.Count} partial results.");
                 return (all, true);
             }
 
-            Log.LogInformation($"Fetching page with offset {currentOffset} and size {pageSize}");
+            Log.LogInformation($"Fetching page {currentPage} (records {currentPage * pageSize}–{currentPage * pageSize + pageSize - 1}) of size {pageSize}");
             for (int attempt = 0; ; attempt++)
             {
                 try
@@ -949,7 +950,7 @@ public class GuiCommand : IWithConfigCommand
                     pagedResponse = await client.QueryInvoiceMetadataAsync(
                         filters,
                         accessToken,
-                        pageOffset: currentOffset,
+                        pageOffset: currentPage,
                         pageSize: pageSize,
                         cancellationToken: ct).ConfigureAwait(false);
                     break;
@@ -959,7 +960,7 @@ public class GuiCommand : IWithConfigCommand
                      ex.ErrorResponse.Exception.ExceptionDetailList.Any(d => d.ExceptionCode == 21405)) ||
                     ex.Message.Contains("21405", StringComparison.Ordinal))
                 {
-                    Log.LogWarning($"KSeF API rejected offset limit (21405) at offset {currentOffset}. Returning {all.Count} partial results.");
+                    Log.LogWarning($"KSeF API rejected page offset (21405) at page {currentPage}. Returning {all.Count} partial results.");
                     return (all, true);
                 }
                 catch (KsefRateLimitException ex) when (attempt < maxRetries && !abortOn429)
@@ -977,11 +978,11 @@ public class GuiCommand : IWithConfigCommand
 
             if (pagedResponse.IsTruncated)
             {
-                Log.LogWarning($"KSeF API returned IsTruncated=true at offset {currentOffset}. Total results exceed 10 000. Returning {all.Count} partial results.");
+                Log.LogWarning($"KSeF API returned IsTruncated=true at page {currentPage}. Total results exceed 10 000. Returning {all.Count} partial results.");
                 return (all, true);
             }
 
-            currentOffset += pageSize;
+            currentPage++;  // advance to next page number
 
             if (pagedResponse.HasMore == true)
             {

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -931,14 +931,14 @@ public class GuiCommand : IWithConfigCommand
         const int pageSize = 100;
         const int maxRetries = 5;
         const int interPageDelayMs = 200;
-        const int maxApiOffset = 10_000;  // KSeF hard limit: pageOffset * pageSize must be < 10 000
+        const int maxRecordCount = 10_000;  // KSeF hard limit: total accessible records (page * pageSize) must be < 10 000
 
         do
         {
             // Guard: page 100 × pageSize 100 = 10 000 records — the API rejects this with 21405.
-            if (currentPage * pageSize >= maxApiOffset)
+            if (currentPage * pageSize >= maxRecordCount)
             {
-                Log.LogWarning($"Reached KSeF API offset limit (page {currentPage}, record {currentPage * pageSize}). Returning {all.Count} partial results.");
+                Log.LogWarning($"Reached KSeF API record count limit (page {currentPage}, record {currentPage * pageSize}). Returning {all.Count} partial results.");
                 return (all, true);
             }
 


### PR DESCRIPTION
The KSeF API `pageOffset` param is a page number, not a record offset. Renamed the tracking variable to reflect this and updated the limit guard to multiply page × pageSize before comparing against the 10k hard limit. Log messages now show both the page number and equivalent record range for clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated pagination logic to use page-based indexing for improved error reporting, with clearer messages displaying page numbers and record ranges in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->