### PR TITLE
feat: add NBP FX rates and net+VAT chart enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="src/KSeFCli/app.png" width="96" alt="ksefcli logo" />
 
-# ksefcli
+# ksef-gui
 
 **Klient KSeF ze wbudowanym interfejsem przeglądarkowym**<br/>
 **KSeF client with a built-in browser GUI**
@@ -26,7 +26,7 @@
 
 > **Fork** projektu [kamilcuk/ksefcli](https://github.com/kamilcuk/ksefcli) autorstwa [Kamila Cukrowskiego](https://github.com/kamilcuk). Oryginalne repozytorium zawiera wersję CLI; ten fork dodaje rozbudowany interfejs przeglądarkowy i dodatkowe funkcje.
 
-`ksefcli` to narzędzie do pobierania faktur z **Krajowego Systemu e-Faktur (KSeF)**. Oprócz CLI posiada wbudowany interfejs przeglądarkowy uruchamiany lokalnie — bez instalowania dodatkowego oprogramowania.
+`ksefcli` to narzędzie do pobierania faktur z **Krajowego Systemu e-Faktur (KSeF)**. Oprócz CLI posiada wbudowany interfejs przeglądarkowy uruchamiany lokalnie (KSEF Gui) — bez instalowania dodatkowego oprogramowania.
 
 ### ✨ Cechy
 

--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ Tytuł wykresu zmienia się w zależności od wybranego typu podmiotu: _Przychod
 - Tooltip (po najechaniu myszą): wartości netto, VAT i brutto danej waluty
 
 **Filtry walut** (chipsy nad wykresem):
-- Kliknięcie chipu filtruje listę faktur do wybranej waluty
-- Każdy chip wyświetla aktualny kurs NBP (np. `EUR (12) 4,2567`)
+- Kliknięcie chipu przełącza widoczność danej waluty w liście faktur (multi-select — można zaznaczyć kilka walut jednocześnie)
+- Każdy chip wyświetla liczbę faktur i aktualny kurs NBP (np. `EUR (12) 4,2567`)
 
 **Podsumowanie w PLN** (pod słupkami):
 - Reaguje na aktywny filtr walut — sumuje tylko zaznaczone waluty (lub wszystkie gdy brak filtru)
@@ -370,44 +370,56 @@ PDF generowany **natywnie** przez [QuestPDF](https://www.questpdf.com/) — czys
 
 Pola wyodrębniane z XML faktury KSeF (schemat FA(3)) i uwzględniane w generowanym pliku PDF:
 
-| Sekcja XML                            | Pole / element                       | Opis                                                      |
-| ------------------------------------- | ------------------------------------ | --------------------------------------------------------- |
-| `Naglowek`                            | `SystemInfo`                         | System wystawiający fakturę (stopka)                      |
-| _(metadane API)_                      | `KsefReferenceNumber`                | **Numer KSeF** (przekazywany z odpowiedzi API, nie z XML) |
-| `Fa`                                  | `P_2`                                | Numer faktury wystawcy                                    |
-| `Fa`                                  | `RodzajFaktury`                      | Typ dokumentu (VAT, KOR, ZAL…)                            |
-| `Fa`                                  | `P_1`                                | Data wystawienia                                          |
-| `Fa`                                  | `P_1M`                               | Miejsce wystawienia                                       |
-| `Fa`                                  | `P_6`                                | Data dostawy / wykonania usługi                           |
-| `Fa` › `OkresFa`                      | `P_6_Od`, `P_6_Do`                   | Okres rozliczeniowy (od–do)                               |
-| `Fa` › `FakturaZaliczkowa`            | `NrFaZaliczkowej`                    | Numer faktury zaliczkowej                                 |
-| `Fa`                                  | `KodWaluty`                          | Waluta                                                    |
-| `Podmiot1`                            | `NIP`, `Nazwa`                       | NIP i nazwa sprzedawcy                                    |
-| `Podmiot1` › `Adres`                  | `KodKraju`, `AdresL1`, `AdresL2`     | Adres sprzedawcy                                          |
-| `Podmiot1` › `DaneKontaktowe`         | `Email`, `Telefon`                   | Kontakt sprzedawcy                                        |
-| `Podmiot1`                            | `NrEORI`                             | Numer EORI sprzedawcy                                     |
-| `Podmiot2`                            | `NIP`, `Nazwa`                       | NIP i nazwa nabywcy                                       |
-| `Podmiot2` › `Adres`                  | `KodKraju`, `AdresL1`, `AdresL2`     | Adres nabywcy                                             |
-| `Podmiot2` › `DaneKontaktowe`         | `Email`                              | E-mail nabywcy                                            |
-| `Podmiot2`                            | `NrKlienta`                          | Numer klienta nabywcy                                     |
-| `Fa` › `FaWiersz`                     | `NrWierszaFa`                        | Numer wiersza                                             |
-| `Fa` › `FaWiersz`                     | `P_7`                                | Nazwa towaru/usługi                                       |
-| `Fa` › `FaWiersz`                     | `P_8A`, `P_8B`                       | Jednostka miary, ilość                                    |
-| `Fa` › `FaWiersz`                     | `P_9A`, `P_9B`                       | Cena jednostkowa netto / brutto                           |
-| `Fa` › `FaWiersz`                     | `P_11`, `P_11A`                      | Wartość netto / brutto                                    |
-| `Fa` › `FaWiersz`                     | `P_12`                               | Stawka VAT                                                |
-| `Fa` › `FaWiersz`                     | `KursWaluty`                         | Kurs waluty pozycji                                       |
-| `Fa` › `FaWiersz`                     | `Indeks`, `GTIN`, `UU_ID`            | Identyfikatory towaru                                     |
-| `Fa`                                  | `P_13_x`, `P_14_x`                   | Sumy netto i VAT per stawka                               |
-| `Fa`                                  | `P_15`                               | Kwota należności ogółem (brutto)                          |
-| `Fa` › `Platnosc`                     | `FormaPlatnosci`                     | Forma płatności                                           |
-| `Fa` › `Platnosc`                     | `TerminPlatnosci` / `Termin`         | Termin(y) płatności                                       |
-| `Fa` › `Platnosc`                     | `Zaplacono`, `DataZaplaty`           | Znacznik zapłacono / data                                 |
-| `Fa` › `Platnosc` › `RachunekBankowy` | `NrRB`, `NazwaBanku`, `OpisRachunku` | Dane rachunku bankowego                                   |
-| `Fa`                                  | `DodatkowyOpis` (`Klucz`, `Wartosc`) | Dodatkowe opisy (pary klucz–wartość)                      |
-| `Fa`                                  | `WZ`                                 | Numer dokumentu WZ                                        |
-| `Fa` › `WarunkiTransakcji` › `Umowy`  | `NrUmowy`                            | Numery umów                                               |
-| `Stopka` › `Rejestry`                 | `PelnaNazwa`, `REGON`, `BDO`         | Dane rejestrowe sprzedawcy                                |
+| Sekcja XML                                    | Pole / element                       | Opis                                                                    |
+| --------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------- |
+| `Naglowek`                                    | `SystemInfo`                         | System wystawiający fakturę (stopka)                                    |
+| _(metadane API)_                              | `KsefReferenceNumber`                | **Numer KSeF** (przekazywany z odpowiedzi API, nie z XML)               |
+| `Fa`                                          | `P_2`                                | Numer faktury wystawcy                                                  |
+| `Fa`                                          | `RodzajFaktury`                      | Typ dokumentu (VAT, KOR, ZAL…)                                          |
+| `Fa`                                          | `P_1`                                | Data wystawienia                                                        |
+| `Fa`                                          | `P_1M`                               | Miejsce wystawienia                                                     |
+| `Fa`                                          | `P_6`                                | Data dostawy / wykonania usługi                                         |
+| `Fa` › `OkresFa`                              | `P_6_Od`, `P_6_Do`                   | Okres rozliczeniowy (od–do)                                             |
+| `Fa` › `FakturaZaliczkowa`                    | `NrFaZaliczkowej`                    | Numer faktury zaliczkowej                                               |
+| `Fa`                                          | `KodWaluty`                          | Waluta                                                                  |
+| `Fa`                                          | `P_KursWaluty`                       | Kurs waluty całej faktury                                               |
+| `Fa`                                          | `P_16`                               | Odwrotne obciążenie — wyróżnione w sekcji Szczegóły                     |
+| `Fa`                                          | `P_17`                               | Samofakturowanie — wyróżnione w sekcji Szczegóły                        |
+| `Fa`                                          | `P_18`                               | Procedura marży (wartość kodu) — wyróżnione w sekcji Szczegóły          |
+| `Fa`                                          | `P_18A`                              | Nowe środki transportu — wyróżnione w sekcji Szczegóły                  |
+| `Fa`                                          | `P_19`, `P_19A`, `P_19B`             | Podstawa zwolnienia z VAT (przepis, opis)                               |
+| `Podmiot1`                                    | `NIP`, `Nazwa`                       | NIP i nazwa sprzedawcy                                                  |
+| `Podmiot1` › `Adres`                          | `KodKraju`, `AdresL1`, `AdresL2`     | Adres sprzedawcy                                                        |
+| `Podmiot1` › `DaneKontaktowe`                 | `Email`, `Telefon`                   | Kontakt sprzedawcy                                                      |
+| `Podmiot1`                                    | `NrEORI`                             | Numer EORI sprzedawcy                                                   |
+| `Podmiot2`                                    | `NIP`, `Nazwa`                       | NIP i nazwa nabywcy                                                     |
+| `Podmiot2` › `Adres`                          | `KodKraju`, `AdresL1`, `AdresL2`     | Adres nabywcy                                                           |
+| `Podmiot2` › `DaneKontaktowe`                 | `Email`                              | E-mail nabywcy                                                          |
+| `Podmiot2`                                    | `NrKlienta`                          | Numer klienta nabywcy                                                   |
+| `Podmiot3`                                    | `NIP`, `Nazwa`, `Adres`, kontakt     | Podmiot trzeci (opcjonalny) — osobny blok pod Sprzedawcą/Nabywcą        |
+| `PodmiotUpowazniony`                          | `NIP`, `Nazwa`, `Adres`, kontakt     | Podmiot upoważniony (opcjonalny) — osobny blok                          |
+| `Fa` › `FaWiersz`                             | `NrWierszaFa`                        | Numer wiersza                                                           |
+| `Fa` › `FaWiersz`                             | `P_7`                                | Nazwa towaru/usługi                                                     |
+| `Fa` › `FaWiersz`                             | `P_8A`, `P_8B`                       | Jednostka miary, ilość                                                  |
+| `Fa` › `FaWiersz`                             | `P_9A`, `P_9B`                       | Cena jednostkowa netto / brutto                                         |
+| `Fa` › `FaWiersz`                             | `P_11`, `P_11A`                      | Wartość netto / brutto                                                  |
+| `Fa` › `FaWiersz`                             | `P_12`                               | Stawka VAT                                                              |
+| `Fa` › `FaWiersz`                             | `KursWaluty`                         | Kurs waluty pozycji                                                     |
+| `Fa` › `FaWiersz`                             | `Indeks`, `GTIN`, `UU_ID`            | Identyfikatory towaru                                                   |
+| `Fa`                                          | `P_13_*`, `P_14_*`                   | Sumy netto i VAT per stawka — **wykrywane dynamicznie**, wszystkie stawki |
+| `Fa`                                          | `P_14_*W`                            | VAT w walucie obcej per stawka — dodatkowa kolumna gdy obecne           |
+| `Fa`                                          | `P_15`                               | Kwota należności ogółem (brutto)                                        |
+| `Fa` › `Platnosc`                             | `FormaPlatnosci`                     | Forma płatności                                                         |
+| `Fa` › `Platnosc`                             | `TerminPlatnosci` / `Termin`         | Termin(y) płatności                                                     |
+| `Fa` › `Platnosc`                             | `Zaplacono`, `DataZaplaty`           | Znacznik zapłacono / data                                               |
+| `Fa` › `Platnosc` › `RachunekBankowy`         | `NrRB`, `NazwaBanku`, `OpisRachunku` | Dane rachunku bankowego                                                 |
+| `Fa`                                          | `DodatkowyOpis` (`Klucz`, `Wartosc`) | Dodatkowe opisy (pary klucz–wartość)                                    |
+| `Fa`                                          | `WZ`                                 | Numer dokumentu WZ                                                      |
+| `Fa` › `WarunkiTransakcji` › `Umowy`          | `NrUmowy`                            | Numery umów                                                             |
+| `Fa` › `WarunkiTransakcji` › `Zamowienia`     | `NrZamowienia`                       | Numery zamówień                                                         |
+| `Fa` › `WarunkiTransakcji`                    | `NrPartiiDostawy`                    | Numer partii dostawy                                                    |
+| `Fa` › `WarunkiTransakcji`                    | `Incoterms`                          | Warunki dostawy (EXW, CIF, DAP…)                                        |
+| `Stopka` › `Rejestry`                         | `PelnaNazwa`, `REGON`, `BDO`         | Dane rejestrowe sprzedawcy                                              |
 
 ---
 
@@ -592,8 +604,8 @@ The chart title adapts to the subject type: _Przychody netto + VAT_ (income) for
 - Tooltip on hover: net, VAT and gross values for that currency
 
 **Currency chips** (above the chart):
-- Click to filter the invoice list to a single currency
-- Each chip shows the current NBP exchange rate (e.g. `EUR (12) 4.2567`)
+- Click to toggle currencies shown in the invoice list (multi-select — multiple chips can be active simultaneously)
+- Each chip shows the invoice count and current NBP exchange rate (e.g. `EUR (12) 4.2567`)
 
 **PLN summary** (below the bars):
 - Reacts to active currency filter — sums only selected currencies (or all if no filter)
@@ -759,44 +771,56 @@ PDFs are rendered by a **native built-in engine** using [QuestPDF](https://www.q
 
 Fields extracted from KSeF invoice XML (FA(3) schema) and included in the generated PDF:
 
-| XML section                           | Field / element                      | Description                                                |
-| ------------------------------------- | ------------------------------------ | ---------------------------------------------------------- |
-| `Naglowek`                            | `SystemInfo`                         | Issuing system name (footer)                               |
-| _(API metadata)_                      | `KsefReferenceNumber`                | **KSeF number** (injected from API response, not from XML) |
-| `Fa`                                  | `P_2`                                | Issuer's invoice number                                    |
-| `Fa`                                  | `RodzajFaktury`                      | Document type (VAT, KOR, ZAL…)                             |
-| `Fa`                                  | `P_1`                                | Issue date                                                 |
-| `Fa`                                  | `P_1M`                               | Place of issue                                             |
-| `Fa`                                  | `P_6`                                | Delivery / service completion date                         |
-| `Fa` › `OkresFa`                      | `P_6_Od`, `P_6_Do`                   | Settlement period (from–to)                                |
-| `Fa` › `FakturaZaliczkowa`            | `NrFaZaliczkowej`                    | Advance invoice number                                     |
-| `Fa`                                  | `KodWaluty`                          | Currency code                                              |
-| `Podmiot1`                            | `NIP`, `Nazwa`                       | Seller tax ID and name                                     |
-| `Podmiot1` › `Adres`                  | `KodKraju`, `AdresL1`, `AdresL2`     | Seller address                                             |
-| `Podmiot1` › `DaneKontaktowe`         | `Email`, `Telefon`                   | Seller contact                                             |
-| `Podmiot1`                            | `NrEORI`                             | Seller EORI number                                         |
-| `Podmiot2`                            | `NIP`, `Nazwa`                       | Buyer tax ID and name                                      |
-| `Podmiot2` › `Adres`                  | `KodKraju`, `AdresL1`, `AdresL2`     | Buyer address                                              |
-| `Podmiot2` › `DaneKontaktowe`         | `Email`                              | Buyer e-mail                                               |
-| `Podmiot2`                            | `NrKlienta`                          | Buyer customer number                                      |
-| `Fa` › `FaWiersz`                     | `NrWierszaFa`                        | Line number                                                |
-| `Fa` › `FaWiersz`                     | `P_7`                                | Item / service name                                        |
-| `Fa` › `FaWiersz`                     | `P_8A`, `P_8B`                       | Unit of measure, quantity                                  |
-| `Fa` › `FaWiersz`                     | `P_9A`, `P_9B`                       | Unit net / gross price                                     |
-| `Fa` › `FaWiersz`                     | `P_11`, `P_11A`                      | Net / gross line total                                     |
-| `Fa` › `FaWiersz`                     | `P_12`                               | VAT rate                                                   |
-| `Fa` › `FaWiersz`                     | `KursWaluty`                         | Line exchange rate                                         |
-| `Fa` › `FaWiersz`                     | `Indeks`, `GTIN`, `UU_ID`            | Item identifiers                                           |
-| `Fa`                                  | `P_13_x`, `P_14_x`                   | Net and VAT subtotals per rate                             |
-| `Fa`                                  | `P_15`                               | Total gross amount                                         |
-| `Fa` › `Platnosc`                     | `FormaPlatnosci`                     | Payment method                                             |
-| `Fa` › `Platnosc`                     | `TerminPlatnosci` / `Termin`         | Payment due date(s)                                        |
-| `Fa` › `Platnosc`                     | `Zaplacono`, `DataZaplaty`           | Paid flag / payment date                                   |
-| `Fa` › `Platnosc` › `RachunekBankowy` | `NrRB`, `NazwaBanku`, `OpisRachunku` | Bank account details                                       |
-| `Fa`                                  | `DodatkowyOpis` (`Klucz`, `Wartosc`) | Additional notes (key–value pairs)                         |
-| `Fa`                                  | `WZ`                                 | WZ document reference                                      |
-| `Fa` › `WarunkiTransakcji` › `Umowy`  | `NrUmowy`                            | Contract number(s)                                         |
-| `Stopka` › `Rejestry`                 | `PelnaNazwa`, `REGON`, `BDO`         | Seller registry data                                       |
+| XML section                                   | Field / element                      | Description                                                              |
+| --------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------ |
+| `Naglowek`                                    | `SystemInfo`                         | Issuing system name (footer)                                             |
+| _(API metadata)_                              | `KsefReferenceNumber`                | **KSeF number** (injected from API response, not from XML)               |
+| `Fa`                                          | `P_2`                                | Issuer's invoice number                                                  |
+| `Fa`                                          | `RodzajFaktury`                      | Document type (VAT, KOR, ZAL…)                                           |
+| `Fa`                                          | `P_1`                                | Issue date                                                               |
+| `Fa`                                          | `P_1M`                               | Place of issue                                                           |
+| `Fa`                                          | `P_6`                                | Delivery / service completion date                                       |
+| `Fa` › `OkresFa`                              | `P_6_Od`, `P_6_Do`                   | Settlement period (from–to)                                              |
+| `Fa` › `FakturaZaliczkowa`                    | `NrFaZaliczkowej`                    | Advance invoice number                                                   |
+| `Fa`                                          | `KodWaluty`                          | Currency code                                                            |
+| `Fa`                                          | `P_KursWaluty`                       | Invoice-level exchange rate                                              |
+| `Fa`                                          | `P_16`                               | Reverse charge — highlighted in Details                                  |
+| `Fa`                                          | `P_17`                               | Self-billing — highlighted in Details                                    |
+| `Fa`                                          | `P_18`                               | Margin scheme (code value) — highlighted in Details                      |
+| `Fa`                                          | `P_18A`                              | New means of transport — highlighted in Details                          |
+| `Fa`                                          | `P_19`, `P_19A`, `P_19B`             | VAT exemption basis, legal reference, description                        |
+| `Podmiot1`                                    | `NIP`, `Nazwa`                       | Seller tax ID and name                                                   |
+| `Podmiot1` › `Adres`                          | `KodKraju`, `AdresL1`, `AdresL2`     | Seller address                                                           |
+| `Podmiot1` › `DaneKontaktowe`                 | `Email`, `Telefon`                   | Seller contact                                                           |
+| `Podmiot1`                                    | `NrEORI`                             | Seller EORI number                                                       |
+| `Podmiot2`                                    | `NIP`, `Nazwa`                       | Buyer tax ID and name                                                    |
+| `Podmiot2` › `Adres`                          | `KodKraju`, `AdresL1`, `AdresL2`     | Buyer address                                                            |
+| `Podmiot2` › `DaneKontaktowe`                 | `Email`                              | Buyer e-mail                                                             |
+| `Podmiot2`                                    | `NrKlienta`                          | Buyer customer number                                                    |
+| `Podmiot3`                                    | `NIP`, `Nazwa`, `Adres`, contact     | Third party (optional) — separate block below Seller/Buyer               |
+| `PodmiotUpowazniony`                          | `NIP`, `Nazwa`, `Adres`, contact     | Authorised entity (optional) — separate block                            |
+| `Fa` › `FaWiersz`                             | `NrWierszaFa`                        | Line number                                                              |
+| `Fa` › `FaWiersz`                             | `P_7`                                | Item / service name                                                      |
+| `Fa` › `FaWiersz`                             | `P_8A`, `P_8B`                       | Unit of measure, quantity                                                |
+| `Fa` › `FaWiersz`                             | `P_9A`, `P_9B`                       | Unit net / gross price                                                   |
+| `Fa` › `FaWiersz`                             | `P_11`, `P_11A`                      | Net / gross line total                                                   |
+| `Fa` › `FaWiersz`                             | `P_12`                               | VAT rate                                                                 |
+| `Fa` › `FaWiersz`                             | `KursWaluty`                         | Line exchange rate                                                       |
+| `Fa` › `FaWiersz`                             | `Indeks`, `GTIN`, `UU_ID`            | Item identifiers                                                         |
+| `Fa`                                          | `P_13_*`, `P_14_*`                   | Net and VAT subtotals per rate — **dynamically discovered**, all rates   |
+| `Fa`                                          | `P_14_*W`                            | Foreign-currency VAT per rate — extra column when present                |
+| `Fa`                                          | `P_15`                               | Total gross amount                                                       |
+| `Fa` › `Platnosc`                             | `FormaPlatnosci`                     | Payment method                                                           |
+| `Fa` › `Platnosc`                             | `TerminPlatnosci` / `Termin`         | Payment due date(s)                                                      |
+| `Fa` › `Platnosc`                             | `Zaplacono`, `DataZaplaty`           | Paid flag / payment date                                                 |
+| `Fa` › `Platnosc` › `RachunekBankowy`         | `NrRB`, `NazwaBanku`, `OpisRachunku` | Bank account details                                                     |
+| `Fa`                                          | `DodatkowyOpis` (`Klucz`, `Wartosc`) | Additional notes (key–value pairs)                                       |
+| `Fa`                                          | `WZ`                                 | WZ document reference                                                    |
+| `Fa` › `WarunkiTransakcji` › `Umowy`          | `NrUmowy`                            | Contract number(s)                                                       |
+| `Fa` › `WarunkiTransakcji` › `Zamowienia`     | `NrZamowienia`                       | Purchase order number(s)                                                 |
+| `Fa` › `WarunkiTransakcji`                    | `NrPartiiDostawy`                    | Delivery batch number                                                    |
+| `Fa` › `WarunkiTransakcji`                    | `Incoterms`                          | Delivery terms (EXW, CIF, DAP…)                                          |
+| `Stopka` › `Rejestry`                         | `PelnaNazwa`, `REGON`, `BDO`         | Seller registry data                                                     |
 
 ---
 
@@ -819,6 +843,16 @@ Fields extracted from KSeF invoice XML (FA(3) schema) and included in the genera
 
 **Poprawki API / API fixes**
 - Naprawiono błąd 21405: `pageOffset` to numer strony (0-based), nie offset rekordu — `currentPage++` zamiast `currentOffset += pageSize`
+
+**PDF — nowe pola FA(3)**
+- `Podmiot3` (podmiot trzeci) — osobny blok pod Sprzedawcą/Nabywcą
+- `PodmiotUpowazniony` — podmiot upoważniony do wystawiania faktur
+- Dynamiczne wykrywanie stawek VAT: skan wszystkich `P_13_*` / `P_14_*` zamiast hardcodowanej listy — obsługuje wszystkie stawki (23%, 8%, 5%, 3%, 0%, zw, np, oo i inne)
+- `P_14_*W` — VAT w walucie obcej jako dodatkowa kolumna w tabeli stawek
+- `P_KursWaluty` — kurs waluty całej faktury w sekcji Szczegóły
+- `P_16` (odwrotne obciążenie), `P_17` (samofakturowanie), `P_18` (procedura marży), `P_18A` (nowe środki transportu) — wyróżnione adnotacje
+- `P_19` / `P_19A` / `P_19B` — podstawa i przepis zwolnienia z VAT
+- `WarunkiTransakcji`: `NrZamowienia`, `NrPartiiDostawy`, `Incoterms`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | 🌐 **GUI w przeglądarce** | Interfejs lokalny dostępny bez instalacji                                                 |
 | 📄 **Eksport PDF**        | Natywny renderer (QuestPDF) — bez Node.js, git ani zewnętrznych narzędzi                  |
 | 📊 **Podsumowanie CSV**   | Zestawienie faktur za wybrany miesiąc — gotowy plik CSV (UTF-8 BOM, separator `;`)        |
-| 📈 **Wykres przychodów**  | Słupki netto + VAT per waluta z przeliczeniem na PLN (kursy NBP) — widoczny przy liście faktur (opt-out) |
+| 📈 **Wykres przychodów / kosztów** | Słupki netto + VAT per waluta z przeliczeniem na PLN (kursy NBP) — widoczny przy liście faktur (opt-out) |
 | 🔄 **Auto-odświeżanie**   | Wyszukiwanie w tle co N minut; powiadomienia o nowych fakturach                           |
 | 🔔 **Powiadomienia**      | Powiadomienia OS, webhooki Slack / Teams oraz e-mail (SMTP) per profil                    |
 | 💾 **Cache SQLite**       | Wyniki wyszukiwania przechowywane lokalnie; przełączanie profili bez ponownego pobierania |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | 🌐 **GUI w przeglądarce** | Interfejs lokalny dostępny bez instalacji                                                 |
 | 📄 **Eksport PDF**        | Natywny renderer (QuestPDF) — bez Node.js, git ani zewnętrznych narzędzi                  |
 | 📊 **Podsumowanie CSV**   | Zestawienie faktur za wybrany miesiąc — gotowy plik CSV (UTF-8 BOM, separator `;`)        |
-| 📈 **Wykres przychodów**  | Poziomy wykres słupkowy sum netto per waluta — widoczny przy liście faktur (opt-out)      |
+| 📈 **Wykres przychodów**  | Słupki netto + VAT per waluta z przeliczeniem na PLN (kursy NBP) — widoczny przy liście faktur (opt-out) |
 | 🔄 **Auto-odświeżanie**   | Wyszukiwanie w tle co N minut; powiadomienia o nowych fakturach                           |
 | 🔔 **Powiadomienia**      | Powiadomienia OS, webhooki Slack / Teams oraz e-mail (SMTP) per profil                    |
 | 💾 **Cache SQLite**       | Wyniki wyszukiwania przechowywane lokalnie; przełączanie profili bez ponownego pobierania |
@@ -171,16 +171,17 @@ Po wyszukaniu faktur przycisk **Podsumowanie CSV** (widoczny na pasku narzędzi 
 
 **Kolumny w pliku:**
 
-| Kolumna          | Opis                        |
-| ---------------- | --------------------------- |
-| Data wystawienia | Data faktury (RRRR-MM-DD)   |
-| Numer faktury    | Numer nadany przez wystawcę |
-| Sprzedawca       | Nazwa sprzedawcy            |
-| NIP sprzedawcy   | NIP sprzedawcy              |
-| Nabywca          | Nazwa nabywcy               |
-| Numer KSeF       | Numer nadany przez KSeF     |
-| Waluta           | Kod waluty (ISO 4217)       |
-| Kwota brutto     | Kwota należności ogółem     |
+| Kolumna          | Opis                                      |
+| ---------------- | ----------------------------------------- |
+| Data wystawienia | Data faktury (RRRR-MM-DD)                 |
+| Numer faktury    | Numer nadany przez wystawcę               |
+| Sprzedawca       | Nazwa sprzedawcy                          |
+| NIP sprzedawcy   | NIP sprzedawcy                            |
+| Nabywca          | Nazwa nabywcy                             |
+| Numer KSeF       | Numer nadany przez KSeF                   |
+| Waluta           | Kod waluty (ISO 4217)                     |
+| Kwota netto      | Suma netto w walucie faktury              |
+| Kwota brutto     | Kwota należności ogółem w walucie faktury |
 
 Na końcu pliku dodawane są sumy brutto pogrupowane według waluty.
 
@@ -188,11 +189,29 @@ Na końcu pliku dodawane są sumy brutto pogrupowane według waluty.
 
 > Podsumowanie generowane jest z danych w lokalnym cache — nie wymaga dodatkowego połączenia z KSeF.
 
-### 📈 Wykres przychodów
+### 📈 Wykres przychodów / kosztów
 
-Po wyszukaniu faktur panel filtrowania walut wyświetla poziomy wykres słupkowy z sumami netto per waluta. Wykres jest widoczny automatycznie gdy lista faktur zawiera dane; można go wyłączyć w **Preferencjach** (checkbox **Pokaż wykres przychodów**).
+Po wyszukaniu faktur panel filtrowania walut wyświetla poziomy wykres słupkowy z sumami **netto + VAT** per waluta. Wykres jest widoczny automatycznie gdy lista faktur zawiera dane; można go wyłączyć w **Preferencjach** (checkbox **Pokaż wykres netto + VAT**).
 
-Kwoty wyświetlane są w formacie polskim (np. `1 234 567,89`). Słupki posortowane są malejąco według wartości.
+Tytuł wykresu zmienia się w zależności od wybranego typu podmiotu: _Przychody netto + VAT_ dla Sprzedawcy, _Koszty netto + VAT_ dla Nabywcy, _Kwoty netto + VAT_ dla pozostałych.
+
+**Każdy słupek:**
+- Część kolorowa = suma netto w walucie faktury
+- Część szara = suma VAT (`brutto − netto`) w tej samej walucie
+- Długości słupków proporcjonalne do największej wartości brutto — słupki małych walut wyświetlane z minimalną widoczną szerokością z zachowaniem proporcji netto/VAT
+- Etykieta: `netto + VAT ≈ netto: X PLN / brutto: Y PLN` (przeliczenie kursami NBP)
+- Tooltip (po najechaniu myszą): wartości netto, VAT i brutto danej waluty
+
+**Filtry walut** (chipsy nad wykresem):
+- Kliknięcie chipu filtruje listę faktur do wybranej waluty
+- Każdy chip wyświetla aktualny kurs NBP (np. `EUR (12) 4,2567`)
+
+**Podsumowanie w PLN** (pod słupkami):
+- Reaguje na aktywny filtr walut — sumuje tylko zaznaczone waluty (lub wszystkie gdy brak filtru)
+- Dla walut obcych: `~ łącznie netto: X PLN / brutto: Y PLN` (znak `~` oznacza wartość przybliżoną)
+- Dla wyłącznie PLN: wartość dokładna (bez `~`)
+
+**Kursy walut** pobierane są automatycznie z publicznego API NBP (Tabela A, kursy średnie), cache 1 godzina. Jeśli kursy nie są jeszcze dostępne, PLN-przeliczenia są pomijane bez wpływu na działanie wykresu.
 
 > Wykres generowany jest z danych w lokalnym cache — nie wymaga połączenia z KSeF.
 
@@ -405,7 +424,7 @@ Pola wyodrębniane z XML faktury KSeF (schemat FA(3)) i uwzględniane w generowa
 | 🌐 **Browser GUI**         | Local interface, no installation needed                                                     |
 | 📄 **PDF export**          | Native renderer (QuestPDF) — no Node.js, git, or external tools                             |
 | 📊 **Monthly CSV summary** | One-click invoice summary for a selected month — Excel-ready CSV (UTF-8 BOM, `;` separator) |
-| 📈 **Income chart**        | Horizontal bar chart of net totals by currency, shown alongside the invoice list (opt-out)  |
+| 📈 **Income/cost chart**   | Net + VAT stacked bars by currency with NBP exchange rate conversion to PLN (opt-out)       |
 | 🔄 **Auto-refresh**        | Background search every N minutes; OS notifications for new invoices                        |
 | 🔔 **Notifications**       | OS desktop notifications, Slack / Teams webhooks, and e-mail (SMTP) per profile             |
 | 💾 **SQLite cache**        | Search results stored locally; profile switching without re-fetching                        |
@@ -541,16 +560,17 @@ After searching, the **Podsumowanie CSV** button (visible in the toolbar next to
 
 **Columns:**
 
-| Column           | Description                     |
-| ---------------- | ------------------------------- |
-| Data wystawienia | Invoice issue date (YYYY-MM-DD) |
-| Numer faktury    | Issuer's invoice number         |
-| Sprzedawca       | Seller name                     |
-| NIP sprzedawcy   | Seller tax ID (NIP)             |
-| Nabywca          | Buyer name                      |
-| Numer KSeF       | KSeF-assigned reference number  |
-| Waluta           | Currency code (ISO 4217)        |
-| Kwota brutto     | Total gross amount              |
+| Column           | Description                             |
+| ---------------- | --------------------------------------- |
+| Data wystawienia | Invoice issue date (YYYY-MM-DD)         |
+| Numer faktury    | Issuer's invoice number                 |
+| Sprzedawca       | Seller name                             |
+| NIP sprzedawcy   | Seller tax ID (NIP)                     |
+| Nabywca          | Buyer name                              |
+| Numer KSeF       | KSeF-assigned reference number          |
+| Waluta           | Currency code (ISO 4217)                |
+| Kwota netto      | Net amount in the invoice's currency    |
+| Kwota brutto     | Total gross amount in invoice's currency |
 
 A per-currency gross total is appended at the end of the file.
 
@@ -558,11 +578,29 @@ A per-currency gross total is appended at the end of the file.
 
 > The summary is generated from the local cache — no additional KSeF connection is required.
 
-### 📈 Income chart
+### 📈 Income / cost chart
 
-After searching, the currency filter panel displays a horizontal bar chart of net totals per currency. The chart appears automatically when invoice data is available; it can be disabled in **Preferences** (the **Show income chart** checkbox).
+After searching, the currency filter panel displays a horizontal bar chart of **net + VAT** stacked totals per currency. The chart appears automatically when invoice data is available; it can be disabled in **Preferences** (the **Show net + VAT chart** checkbox).
 
-Amounts are formatted using Polish locale conventions (e.g. `1 234 567,89`). Bars are sorted descending by value.
+The chart title adapts to the subject type: _Przychody netto + VAT_ (income) for Seller, _Koszty netto + VAT_ (costs) for Buyer, _Kwoty netto + VAT_ (amounts) for others.
+
+**Each bar:**
+- Coloured segment = net total in the invoice's currency
+- Grey segment = VAT total (`gross − net`) in the same currency; proportional to the net segment
+- Bars scale proportionally to the largest gross value; small currencies maintain correct net/VAT ratio
+- Label: `net + VAT ≈ net: X PLN / gross: Y PLN` (converted at current NBP rates)
+- Tooltip on hover: net, VAT and gross values for that currency
+
+**Currency chips** (above the chart):
+- Click to filter the invoice list to a single currency
+- Each chip shows the current NBP exchange rate (e.g. `EUR (12) 4.2567`)
+
+**PLN summary** (below the bars):
+- Reacts to active currency filter — sums only selected currencies (or all if no filter)
+- For foreign currencies: `~ łącznie netto: X PLN / brutto: Y PLN` (the `~` indicates approximation)
+- For PLN-only: exact total without `~`
+
+**Exchange rates** are fetched automatically from the public NBP API (Table A, mid rates), cached for 1 hour. If rates are unavailable, PLN conversions are silently skipped without affecting chart display.
 
 > The chart is generated from the local cache — no KSeF connection required.
 
@@ -759,6 +797,36 @@ Fields extracted from KSeF invoice XML (FA(3) schema) and included in the genera
 | `Fa`                                  | `WZ`                                 | WZ document reference                                      |
 | `Fa` › `WarunkiTransakcji` › `Umowy`  | `NrUmowy`                            | Contract number(s)                                         |
 | `Stopka` › `Rejestry`                 | `PelnaNazwa`, `REGON`, `BDO`         | Seller registry data                                       |
+
+---
+
+## 📋 Changelog
+
+### 0.6.1
+
+**Wykres walut / Currency chart**
+- Słupki netto + VAT: każdy słupek składa się z części netto (kolor waluty) i VAT (szary), proporcjonalnie skalowanych
+- Poprawna kolejność kolumn w tabeli faktur: netto → VAT → brutto → waluta
+- Kurs walut NBP: chipy walutowe wyświetlają aktualny kurs (np. `EUR (12) 4,2567`), pobierany z publicznego API NBP (Tabela A, cache 1 h)
+- Przeliczenie na PLN: etykiety słupków pokazują przybliżone wartości `≈ netto: X PLN / brutto: Y PLN`
+- Podsumowanie w PLN pod wykresem, reaktywne na filtr walut; `~` dla walut obcych, wartość dokładna dla PLN
+- Dynamiczny tytuł wykresu: Przychody / Koszty / Kwoty w zależności od typu podmiotu
+- Poprawna obsługa faktur korygujących: kwota VAT prawidłowo korygowana w dół
+
+**Tabela faktur / Invoice table**
+- Nowe kolumny: Kwota netto i VAT (`brutto − netto`) obok Kwoty brutto — wszystkie sortowalne
+- Kolumna VAT obliczana w walucie faktury (nie PLN)
+
+**Poprawki API / API fixes**
+- Naprawiono błąd 21405: `pageOffset` to numer strony (0-based), nie offset rekordu — `currentPage++` zamiast `currentOffset += pageSize`
+
+---
+
+### 0.6.0
+
+- Wykres przychodów netto per waluta (opt-out)
+- Segment VAT w wykresie walutowym
+- Powiadomienia e-mail (SMTP/STARTTLS)
 
 ---
 

--- a/src/KSeFCli.Tests/PdfGenerationTests.cs
+++ b/src/KSeFCli.Tests/PdfGenerationTests.cs
@@ -189,9 +189,10 @@ public class PdfGenerationTests
         Assert.Equal("3900.00", vat23.Net);
         Assert.Equal("897.00", vat23.Vat);
 
-        VatRow vatZw = Assert.Single(d.VatRows, v => v.Rate == "zw");
-        Assert.Equal("1000.00", vatZw.Net);
-        Assert.Null(vatZw.Vat);
+        // P_13_7 = "niepodlegający opodatkowaniu" (np), not "zwolniony" (zw=P_13_6)
+        VatRow vatNp = Assert.Single(d.VatRows, v => v.Rate == "np");
+        Assert.Equal("1000.00", vatNp.Net);
+        Assert.Null(vatNp.Vat);
     }
 
     [Fact]

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -207,7 +207,7 @@ internal static class KSeFInvoiceParser
         // VAT summary — dynamic scan of all P_13_* present in Fa (schema-driven, no hardcoded rate list)
         List<VatRow> vatRows = fa.Elements()
             .Where(e => e.Name.LocalName.StartsWith("P_13_", StringComparison.Ordinal))
-            .OrderBy(e => e.Name.LocalName, StringComparer.Ordinal)
+            .OrderBy(e => int.TryParse(e.Name.LocalName["P_13_".Length..], out int n) ? n : int.MaxValue)
             .Select(e =>
             {
                 string suffix = e.Name.LocalName["P_13_".Length..];
@@ -1535,8 +1535,11 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                 {
                     string bg = i % 2 == 0 ? Colors.White : LightGray;
                     decimal net = Parse(row.Net);
-                    // Use VatW (invoice currency) when present; fall back to Vat (PLN) for PLN invoices
-                    decimal vatForBrutto = !string.IsNullOrEmpty(row.VatW) ? Parse(row.VatW) : Parse(row.Vat);
+                    // VatW = VAT in invoice currency; Vat = PLN-recalculated.
+                    // Only fall back to Vat when the invoice is in PLN — never add PLN VAT to a foreign-currency net.
+                    decimal vatForBrutto = !string.IsNullOrEmpty(row.VatW) ? Parse(row.VatW)
+                        : d.Waluta == "PLN" ? Parse(row.Vat)
+                        : 0m;
                     string brutto = (net + vatForBrutto).ToString("F2", CultureInfo.InvariantCulture);
 
                     table.Cell().Background(bg).BorderBottom(0.5f).BorderColor(BorderGray).Padding(3)

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -42,7 +42,8 @@ internal record InvoiceLine(
     string? ExchangeRate
 );
 
-internal record VatRow(string Rate, string? Net, string? Vat);
+// VatW = VAT in the invoice's own currency (P_14_*W); null for PLN invoices
+internal record VatRow(string Rate, string? Net, string? Vat, string? VatW = null);
 
 internal record BankAccount(string? NrRB, string? NazwaBanku, string? OpisRachunku);
 
@@ -53,10 +54,13 @@ internal record InvoiceData(
     string? MiejsceWystawienia,
     string? DataDostawy,      // P_6
     string? Waluta,
+    string? KursWalutyFaktury, // P_KursWaluty in Fa — invoice-level exchange rate
     string? OkresOd,
     string? OkresDo,
     InvoiceParty Sprzedawca,
     InvoiceParty Nabywca,
+    InvoiceParty? PodmiotTrzeci,
+    InvoiceParty? PodmiotUpowazniony,
     List<InvoiceLine> Wiersze,
     List<VatRow> VatRows,
     string? RazemBrutto,
@@ -69,6 +73,16 @@ internal record InvoiceData(
     string? WZ,
     List<string> NrUmowy,
     string? NrFaZaliczkowej,
+    bool OdwrotneObciazenie,
+    bool Samofakturowanie,
+    string? ProceduraMarzy,
+    bool NoweŚrodkiTransportu,
+    string? PodstawaZwolnienia,
+    string? PodstawaZwolnieniaA,
+    string? PodstawaZwolnieniaB,
+    List<string> NrZamowienia,
+    string? NrPartiiDostawy,
+    string? Incoterms,
     string? PelnaNazwa,
     string? Regon,
     string? Bdo,
@@ -126,7 +140,22 @@ internal static class KSeFInvoiceParser
         XElement naglowek = El(root, "Naglowek")!;
         XElement podmiot1 = El(root, "Podmiot1")!;
         XElement podmiot2 = El(root, "Podmiot2")!;
+        XElement? podmiot3 = El(root, "Podmiot3");
+        XElement? podmiotUpowazniony = El(root, "PodmiotUpowazniony");
         XElement fa = El(root, "Fa")!;
+
+        static string SuffixToRate(string suffix) => suffix switch
+        {
+            "1" => "23%",
+            "2" => "8%",
+            "3" => "5%",
+            "4" => "3%",
+            "5" => "0% (WDT)",
+            "6" => "zw",
+            "7" => "np",
+            "8" => "oo",
+            _ => suffix
+        };
         XElement? stopka = El(root, "Stopka");
 
         InvoiceParty ParseParty(XElement p)
@@ -166,25 +195,22 @@ internal static class KSeFInvoiceParser
             .OrderBy(w => w.Nr)
             .ToList();
 
-        // VAT summary
-        List<VatRow> vatRows = new List<VatRow>();
-        (string Rate, string NetField, string? VatField)[] vatMap = new (string Rate, string NetField, string? VatField)[]
-        {
-            ("23%", "P_13_1", "P_14_1"),
-            ("8%",  "P_13_2", "P_14_2"),
-            ("5%",  "P_13_3", "P_14_3"),
-            ("0%",  "P_13_6", null),
-            ("zw",  "P_13_7", null),
-            ("np",  "P_13_8", null),
-        };
-        foreach ((string? rate, string? netF, string? vatF) in vatMap)
-        {
-            string? net = Val(fa, netF);
-            if (!string.IsNullOrEmpty(net))
+        // VAT summary — dynamic scan of all P_13_* present in Fa (schema-driven, no hardcoded rate list)
+        List<VatRow> vatRows = fa.Elements()
+            .Where(e => e.Name.LocalName.StartsWith("P_13_", StringComparison.Ordinal))
+            .OrderBy(e => e.Name.LocalName, StringComparer.Ordinal)
+            .Select(e =>
             {
-                vatRows.Add(new VatRow(rate, net, vatF is null ? null : Val(fa, vatF)));
-            }
-        }
+                string suffix = e.Name.LocalName["P_13_".Length..];
+                return new VatRow(
+                    Rate: SuffixToRate(suffix),
+                    Net: e.Value.Trim(),
+                    Vat: Val(fa, "P_14_" + suffix),
+                    VatW: Val(fa, "P_14_" + suffix + "W")
+                );
+            })
+            .Where(r => !string.IsNullOrEmpty(r.Net))
+            .ToList();
 
         List<(string Klucz, string Wartosc)> dodOpis = Els(fa, "DodatkowyOpis")
             .Select(d => (Klucz: Val(d, "Klucz") ?? "", Wartosc: Val(d, "Wartosc") ?? ""))
@@ -226,6 +252,9 @@ internal static class KSeFInvoiceParser
 
         XElement? warunki = El(fa, "WarunkiTransakcji");
         List<string> umowy = new List<string>();
+        List<string> zamowienia = new List<string>();
+        string? nrPartiiDostawy = null;
+        string? incoterms = null;
         if (warunki is not null)
         {
             XElement? umowyEl = El(warunki, "Umowy");
@@ -233,6 +262,13 @@ internal static class KSeFInvoiceParser
             {
                 umowy.AddRange(Els(umowyEl, "NrUmowy").Select(u => u.Value.Trim()));
             }
+            XElement? zamEl = El(warunki, "Zamowienia");
+            if (zamEl is not null)
+            {
+                zamowienia.AddRange(Els(zamEl, "NrZamowienia").Select(z => z.Value.Trim()));
+            }
+            nrPartiiDostawy = Val(warunki, "NrPartiiDostawy");
+            incoterms = Val(warunki, "Incoterms");
         }
 
         XElement? faZal = El(fa, "FakturaZaliczkowa");
@@ -248,10 +284,13 @@ internal static class KSeFInvoiceParser
             MiejsceWystawienia: Val(fa, "P_1M"),
             DataDostawy: Val(fa, "P_6"),
             Waluta: Val(fa, "KodWaluty") ?? "PLN",
+            KursWalutyFaktury: Val(fa, "P_KursWaluty") ?? Val(fa, "KursWaluty"),
             OkresOd: okresEl is null ? null : Val(okresEl, "P_6_Od"),
             OkresDo: okresEl is null ? null : Val(okresEl, "P_6_Do"),
             Sprzedawca: ParseParty(podmiot1),
             Nabywca: ParseParty(podmiot2),
+            PodmiotTrzeci: podmiot3 is null ? null : ParseParty(podmiot3),
+            PodmiotUpowazniony: podmiotUpowazniony is null ? null : ParseParty(podmiotUpowazniony),
             Wiersze: wiersze,
             VatRows: vatRows,
             RazemBrutto: Val(fa, "P_15"),
@@ -264,6 +303,16 @@ internal static class KSeFInvoiceParser
             WZ: Val(fa, "WZ"),
             NrUmowy: umowy,
             NrFaZaliczkowej: nrFaZal,
+            OdwrotneObciazenie: Val(fa, "P_16") == "1",
+            Samofakturowanie: Val(fa, "P_17") == "1",
+            ProceduraMarzy: Val(fa, "P_18"),
+            NoweŚrodkiTransportu: Val(fa, "P_18A") == "1",
+            PodstawaZwolnienia: Val(fa, "P_19"),
+            PodstawaZwolnieniaA: Val(fa, "P_19A"),
+            PodstawaZwolnieniaB: Val(fa, "P_19B"),
+            NrZamowienia: zamowienia,
+            NrPartiiDostawy: nrPartiiDostawy,
+            Incoterms: incoterms,
             PelnaNazwa: rejestry is null ? null : Val(rejestry, "PelnaNazwa"),
             Regon: rejestry is null ? null : Val(rejestry, "REGON"),
             Bdo: rejestry is null ? null : Val(rejestry, "BDO"),
@@ -529,6 +578,9 @@ internal static class KSeFInvoiceSanitizer
         OkresDo = SanitizeDate(d.OkresDo),
         Sprzedawca = SanitizeParty(d.Sprzedawca),
         Nabywca = SanitizeParty(d.Nabywca),
+        PodmiotTrzeci = d.PodmiotTrzeci is null ? null : SanitizeParty(d.PodmiotTrzeci),
+        PodmiotUpowazniony = d.PodmiotUpowazniony is null ? null : SanitizeParty(d.PodmiotUpowazniony),
+        KursWalutyFaktury = SanitizeKwotowy2(d.KursWalutyFaktury),
         Wiersze = d.Wiersze.Select(SanitizeLine).ToList(),
         VatRows = d.VatRows.Select(SanitizeVatRow).ToList(),
         RazemBrutto = SanitizeKwotowy(d.RazemBrutto),
@@ -543,6 +595,12 @@ internal static class KSeFInvoiceSanitizer
         WZ = Text(d.WZ),
         NrUmowy = d.NrUmowy.Select(u => Text(u) ?? "").ToList(),
         NrFaZaliczkowej = Text(d.NrFaZaliczkowej),
+        PodstawaZwolnienia = Text(d.PodstawaZwolnienia),
+        PodstawaZwolnieniaA = Text(d.PodstawaZwolnieniaA),
+        PodstawaZwolnieniaB = Text(d.PodstawaZwolnieniaB),
+        NrZamowienia = d.NrZamowienia.Select(z => Text(z) ?? "").ToList(),
+        NrPartiiDostawy = Text(d.NrPartiiDostawy),
+        Incoterms = Text(d.Incoterms),
         PelnaNazwa = Name(d.PelnaNazwa),
         Regon = SanitizeRegon(d.Regon),
         Bdo = Text(d.Bdo),
@@ -582,6 +640,7 @@ internal static class KSeFInvoiceSanitizer
     {
         Net = SanitizeKwotowy(r.Net),
         Vat = SanitizeKwotowy(r.Vat),
+        VatW = SanitizeKwotowy(r.VatW),
     };
 
     private static BankAccount SanitizeBank(BankAccount b) => b with
@@ -966,6 +1025,24 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                 row.ConstantItem(10);
                 row.RelativeItem().Element(c2 => PartyBox(c2, "Nabywca", d.Nabywca));
             });
+            if (d.PodmiotTrzeci is not null)
+            {
+                col.Item().PaddingTop(6).Row(row =>
+                {
+                    row.RelativeItem().Element(c2 => PartyBox(c2, "Podmiot trzeci", d.PodmiotTrzeci));
+                    row.ConstantItem(10);
+                    row.RelativeItem();
+                });
+            }
+            if (d.PodmiotUpowazniony is not null)
+            {
+                col.Item().PaddingTop(6).Row(row =>
+                {
+                    row.RelativeItem().Element(c2 => PartyBox(c2, "Podmiot upoważniony", d.PodmiotUpowazniony));
+                    row.ConstantItem(10);
+                    row.RelativeItem();
+                });
+            }
 
             // Details bar
             col.Item().PaddingTop(8).BorderTop(0.5f).BorderColor(BorderGray)
@@ -1014,6 +1091,77 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                         {
                             t.Span("Faktura zaliczkowa: ").FontSize(7.5f).FontColor(Gray);
                             t.Span(d.NrFaZaliczkowej).FontSize(7.5f);
+                        });
+                    }
+                    if (!string.IsNullOrEmpty(d.KursWalutyFaktury))
+                    {
+                        det.Item().PaddingTop(2).Text(t =>
+                        {
+                            t.Span("Kurs waluty: ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.KursWalutyFaktury).FontSize(7.5f).Bold();
+                        });
+                    }
+                    // Special procedure flags
+                    List<string> flags = new List<string>();
+                    if (d.OdwrotneObciazenie) { flags.Add("Odwrotne obciążenie (P_16)"); }
+                    if (d.Samofakturowanie) { flags.Add("Samofakturowanie (P_17)"); }
+                    if (!string.IsNullOrEmpty(d.ProceduraMarzy)) { flags.Add("Procedura marży: " + d.ProceduraMarzy); }
+                    if (d.NoweŚrodkiTransportu) { flags.Add("Nowe środki transportu (P_18A)"); }
+                    foreach (string flag in flags)
+                    {
+                        det.Item().PaddingTop(2).Text(t =>
+                        {
+                            t.Span(flag).FontSize(7.5f).Bold().FontColor(RedAccent);
+                        });
+                    }
+                    // VAT exemption basis
+                    if (!string.IsNullOrEmpty(d.PodstawaZwolnienia))
+                    {
+                        det.Item().PaddingTop(2).Text(t =>
+                        {
+                            t.Span("Podstawa zwolnienia (P_19): ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.PodstawaZwolnienia).FontSize(7.5f);
+                        });
+                    }
+                    if (!string.IsNullOrEmpty(d.PodstawaZwolnieniaA))
+                    {
+                        det.Item().PaddingTop(1).Text(t =>
+                        {
+                            t.Span("Przepis (P_19A): ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.PodstawaZwolnieniaA).FontSize(7.5f);
+                        });
+                    }
+                    if (!string.IsNullOrEmpty(d.PodstawaZwolnieniaB))
+                    {
+                        det.Item().PaddingTop(1).Text(t =>
+                        {
+                            t.Span("Opis zwolnienia (P_19B): ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.PodstawaZwolnieniaB).FontSize(7.5f);
+                        });
+                    }
+                    // Transaction conditions
+                    if (d.NrZamowienia.Count > 0)
+                    {
+                        det.Item().PaddingTop(2).Text(t =>
+                        {
+                            t.Span("Nr zamówienia: ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(string.Join(", ", d.NrZamowienia)).FontSize(7.5f);
+                        });
+                    }
+                    if (!string.IsNullOrEmpty(d.NrPartiiDostawy))
+                    {
+                        det.Item().PaddingTop(2).Text(t =>
+                        {
+                            t.Span("Nr partii dostawy: ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.NrPartiiDostawy).FontSize(7.5f);
+                        });
+                    }
+                    if (!string.IsNullOrEmpty(d.Incoterms))
+                    {
+                        det.Item().PaddingTop(2).Text(t =>
+                        {
+                            t.Span("Incoterms: ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.Incoterms).FontSize(7.5f).Bold();
                         });
                     }
                 });
@@ -1348,6 +1496,7 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
 
     private void VatTable(IContainer c, InvoiceData d)
     {
+        bool hasVatW = d.VatRows.Any(r => !string.IsNullOrEmpty(r.VatW));
         c.Column(col =>
         {
             col.Item().Text("Podsumowanie stawek podatku").FontSize(9).Bold().FontColor(Colors.Black);
@@ -1358,7 +1507,8 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                     cols.ConstantColumn(18);  // Lp
                     cols.ConstantColumn(55);  // Stawka
                     cols.ConstantColumn(70);  // Netto
-                    cols.ConstantColumn(60);  // VAT
+                    cols.ConstantColumn(60);  // VAT (PLN)
+                    if (hasVatW) { cols.ConstantColumn(60); } // VAT walutowy
                     cols.ConstantColumn(70);  // Brutto
                 });
                 table.Header(h =>
@@ -1366,7 +1516,10 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                     void Th(string t) =>
                         h.Cell().Background(Blue).Padding(3)
                             .Text(t).FontSize(6.5f).Bold().FontColor(Colors.White);
-                    Th("Lp."); Th("Stawka podatku"); Th("Kwota netto"); Th("Kwota podatku"); Th("Kwota brutto");
+                    Th("Lp."); Th("Stawka podatku"); Th("Kwota netto");
+                    Th("Kwota podatku");
+                    if (hasVatW) { Th($"VAT ({d.Waluta})"); }
+                    Th("Kwota brutto");
                 });
 
                 foreach ((VatRow? row, int i) in d.VatRows.Select((r, i) => (r, i)))
@@ -1384,6 +1537,11 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                         .Text(row.Net ?? "0.00").FontSize(7.5f).AlignRight();
                     table.Cell().Background(bg).BorderBottom(0.5f).BorderColor(BorderGray).Padding(3)
                         .Text(row.Vat ?? "0.00").FontSize(7.5f).AlignRight();
+                    if (hasVatW)
+                    {
+                        table.Cell().Background(bg).BorderBottom(0.5f).BorderColor(BorderGray).Padding(3)
+                            .Text(row.VatW ?? "—").FontSize(7.5f).AlignRight();
+                    }
                     table.Cell().Background(bg).BorderBottom(0.5f).BorderColor(BorderGray).Padding(3)
                         .Text(brutto).FontSize(7.5f).AlignRight();
                 }

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -103,6 +103,27 @@ internal static class KSeFInvoiceParser
     // 10 MB ceiling — a real KSeF invoice is well under 1 MB
     private const long MaxXmlBytes = 10 * 1024 * 1024;
 
+    // Mapping from P_13_* suffix to human-readable VAT rate label per FA(3) schema.
+    // Unknown suffixes fall back to the raw suffix string.
+    private static readonly IReadOnlyDictionary<string, string> VatSuffixLabels =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["1"] = "23%",
+            ["2"] = "8%",
+            ["3"] = "5%",
+            ["4"] = "3%",
+            ["5"] = "0% (WDT)",
+            ["6"] = "zw",
+            ["7"] = "np",
+            ["8"] = "oo",
+            ["9"] = "0% (eksport)",
+            ["10"] = "0% (transport)",
+            ["11"] = "zw (inne)",
+        };
+
+    private static string SuffixToRate(string suffix) =>
+        VatSuffixLabels.TryGetValue(suffix, out string? label) ? label : suffix;
+
     public static InvoiceData Parse(string xmlContent)
     {
         if (System.Text.Encoding.UTF8.GetByteCount(xmlContent) > MaxXmlBytes)
@@ -144,18 +165,6 @@ internal static class KSeFInvoiceParser
         XElement? podmiotUpowazniony = El(root, "PodmiotUpowazniony");
         XElement fa = El(root, "Fa")!;
 
-        static string SuffixToRate(string suffix) => suffix switch
-        {
-            "1" => "23%",
-            "2" => "8%",
-            "3" => "5%",
-            "4" => "3%",
-            "5" => "0% (WDT)",
-            "6" => "zw",
-            "7" => "np",
-            "8" => "oo",
-            _ => suffix
-        };
         XElement? stopka = El(root, "Stopka");
 
         InvoiceParty ParseParty(XElement p)
@@ -1526,8 +1535,9 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                 {
                     string bg = i % 2 == 0 ? Colors.White : LightGray;
                     decimal net = Parse(row.Net);
-                    decimal vat = Parse(row.Vat);
-                    string brutto = (net + vat).ToString("F2", CultureInfo.InvariantCulture);
+                    // Use VatW (invoice currency) when present; fall back to Vat (PLN) for PLN invoices
+                    decimal vatForBrutto = !string.IsNullOrEmpty(row.VatW) ? Parse(row.VatW) : Parse(row.Vat);
+                    string brutto = (net + vatForBrutto).ToString("F2", CultureInfo.InvariantCulture);
 
                     table.Cell().Background(bg).BorderBottom(0.5f).BorderColor(BorderGray).Padding(3)
                         .Text((i + 1).ToString()).FontSize(7.5f).AlignCenter();

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -604,6 +604,7 @@ internal static class KSeFInvoiceSanitizer
         WZ = Text(d.WZ),
         NrUmowy = d.NrUmowy.Select(u => Text(u) ?? "").ToList(),
         NrFaZaliczkowej = Text(d.NrFaZaliczkowej),
+        ProceduraMarzy = Text(d.ProceduraMarzy),
         PodstawaZwolnienia = Text(d.PodstawaZwolnienia),
         PodstawaZwolnieniaA = Text(d.PodstawaZwolnieniaA),
         PodstawaZwolnieniaB = Text(d.PodstawaZwolnieniaB),
@@ -1526,7 +1527,7 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                         h.Cell().Background(Blue).Padding(3)
                             .Text(t).FontSize(6.5f).Bold().FontColor(Colors.White);
                     Th("Lp."); Th("Stawka podatku"); Th("Kwota netto");
-                    Th("Kwota podatku");
+                    Th(hasVatW ? "VAT (PLN)" : "Kwota podatku");
                     if (hasVatW) { Th($"VAT ({d.Waluta})"); }
                     Th("Kwota brutto");
                 });

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2072,8 +2072,11 @@ function renderTable() {
   let sorted = [...getFilteredInvoices()];
   if (sortCol !== null) {
     sorted.sort((a,b) => {
-      let va = sortCol === '_vat' ? ((a.grossAmount ?? 0) - (a.netAmount ?? 0)) : (a[sortCol] ?? '');
-      let vb = sortCol === '_vat' ? ((b.grossAmount ?? 0) - (b.netAmount ?? 0)) : (b[sortCol] ?? '');
+      let va = sortCol === '_vat' ? (a.grossAmount != null && a.netAmount != null ? a.grossAmount - a.netAmount : null) : (a[sortCol] ?? '');
+      let vb = sortCol === '_vat' ? (b.grossAmount != null && b.netAmount != null ? b.grossAmount - b.netAmount : null) : (b[sortCol] ?? '');
+      if (va == null && vb == null) { return 0; }
+      if (va == null) { return sortAsc ? 1 : -1; }
+      if (vb == null) { return sortAsc ? -1 : 1; }
       if (typeof va === 'number' && typeof vb === 'number') return sortAsc ? va - vb : vb - va;
       va = String(va).toLowerCase(); vb = String(vb).toLowerCase();
       return sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
@@ -2484,6 +2487,7 @@ async function silentRefresh() {
       setStatus('Auto-od\u015Bwie\u017Canie: ' + total + ' faktur.', 'idle');
     }
     buildCurrencyFilter();
+    refreshExchangeRates(); // async — keeps PLN conversions fresh during background refreshes
     renderTable();
     checkExisting();
     await fetchTokenStatus();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2030,8 +2030,11 @@ function buildCurrencyFilter() {
       totalGrossPln += (net + vat) * rate;
     }
     let summaryHtml = '';
+    const allRatesMissing = hasNonPln && missingRate && totalNetPln === 0 && totalGrossPln === 0;
     if (hasNonPln && Object.keys(fxRates).length === 0) {
       summaryHtml = '<div class="hbar-summary hbar-summary-wait">Oczekiwanie na kursy NBP…</div>';
+    } else if (allRatesMissing) {
+      summaryHtml = '<div class="hbar-summary hbar-summary-wait">Brak kursów NBP dla wybranych walut</div>';
     } else if (summaryEntries.length > 0) {
       const prefix = hasNonPln ? '~ ' : '';
       const missing = missingRate ? ' <span class="hbar-summary-warn">(brak kursu dla niektórych walut)</span>' : '';

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1269,6 +1269,8 @@ let lastSearchParams = null;        // params of last successful search; null = 
 let showIncomeChart = true;         // opt-out pref — read from /prefs on load
 let fxRates = {};                   // { EUR: 4.25, HUF: 0.011, ... } — PLN per 1 unit, fetched from NBP
 let fxRatesFetchedAt = 0;           // epoch ms of last successful fetch
+let fxRatesFetchInProgress = false; // true while the NBP request is in-flight
+let fxRatesFetchFailed = false;     // true after a failed fetch (distinct from "never fetched")
 
 // Set default month to current month and keep Od/Do consistent
 (function initDates() {
@@ -1927,19 +1929,26 @@ function fmtAmt(v) {
 // On success re-renders the currency filter bar so PLN equivalents appear without a page reload.
 async function refreshExchangeRates() {
   if (Date.now() - fxRatesFetchedAt < 3_600_000) { return; }
+  if (fxRatesFetchInProgress) { return; }
+  fxRatesFetchInProgress = true;
   try {
     const res = await fetch('https://api.nbp.pl/api/exchangerates/tables/A/?format=json', { signal: AbortSignal.timeout(5000) });
-    if (!res.ok) { return; }
+    if (!res.ok) { fxRatesFetchFailed = true; buildCurrencyFilter(); return; }
     const data = await res.json();
     const updated = {};
     for (const rate of data[0].rates) { updated[rate.code] = rate.mid; }
     updated['PLN'] = 1;
     fxRates = updated;
     fxRatesFetchedAt = Date.now();
+    fxRatesFetchFailed = false;
     console.log('[FX] NBP rates refreshed:', Object.keys(fxRates).length, 'currencies, effective', data[0].effectiveDate);
     buildCurrencyFilter(); // re-render so PLN equivalents appear immediately
   } catch (e) {
+    fxRatesFetchFailed = true;
     console.warn('[FX] NBP rate fetch failed:', e.message);
+    buildCurrencyFilter();
+  } finally {
+    fxRatesFetchInProgress = false;
   }
 }
 
@@ -2002,8 +2011,11 @@ function buildCurrencyFilter() {
       const color = colorMap[cur] || CHART_PALETTE[0];
       // Negative net (corrections dominate): render muted bar, label shows sign
       const barColor = isNeg ? '#ef9a9a' : color; // red-200 for net-negative currencies
-      const netPct = Math.max(MIN_PCT, (absNet / maxVal) * 100);
-      const vatPct = absNet > 0 ? Math.min((absVat / absNet) * netPct, 100 - netPct) : 0;
+      // Clamp the total bar (net+vat together) to MIN_PCT, then split proportionally.
+      // This prevents a fake net bar when absNet===0 (e.g. cancellation-only currencies).
+      const totalPct = Math.max(MIN_PCT, ((absNet + absVat) / maxVal) * 100);
+      const netPct = absNet === 0 ? 0 : (absNet / (absNet + absVat || 1)) * totalPct;
+      const vatPct = totalPct - netPct;
       const tooltip = cur + ': netto ' + fmtAmt(net) + ', VAT ' + fmtAmt(vat) + ', brutto ' + fmtAmt(gross);
       const vatStyle = 'width:' + vatPct + '%;flex-shrink:0;background:' + VAT_COLOR;
       barsHtml += '<div class="hbar-row" title="' + tooltip + '">' +
@@ -2032,7 +2044,11 @@ function buildCurrencyFilter() {
     }
     let summaryHtml = '';
     const allRatesMissing = hasNonPln && missingRate && !convertedAny;
-    if (hasNonPln && Object.keys(fxRates).length === 0) {
+    if (hasNonPln && fxRatesFetchInProgress) {
+      summaryHtml = '<div class="hbar-summary hbar-summary-wait">Oczekiwanie na kursy NBP…</div>';
+    } else if (hasNonPln && fxRatesFetchFailed && Object.keys(fxRates).length === 0) {
+      summaryHtml = '<div class="hbar-summary hbar-summary-warn">Nie udało się pobrać kursów NBP</div>';
+    } else if (hasNonPln && Object.keys(fxRates).length === 0) {
       summaryHtml = '<div class="hbar-summary hbar-summary-wait">Oczekiwanie na kursy NBP…</div>';
     } else if (allRatesMissing) {
       summaryHtml = '<div class="hbar-summary hbar-summary-wait">Brak kursów NBP dla wybranych walut</div>';

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -722,11 +722,17 @@ td input[type=checkbox]{cursor:pointer;width:1rem;height:1rem}
 .hbar-track{flex:1;background:#e8e8e8;border-radius:3px;height:10px;overflow:hidden;display:flex;align-items:stretch}
 .hbar-fill{transition:width .35s}
 .hbar-amt{font-size:.88rem;color:#555;white-space:nowrap;min-width:10rem;text-align:right;flex-shrink:0}
+.hbar-pln{font-size:.78rem;color:#999;margin-left:.3rem}
+.hbar-summary{font-size:.8rem;color:#666;margin-top:.4rem;padding-top:.35rem;border-top:1px solid #e0e0e0}
+.hbar-summary b{color:#444}
+.hbar-summary-warn{color:#e57373;font-size:.75rem}
+.hbar-summary-wait{font-style:italic;color:#aaa}
 .hbar-chart-title{font-size:.75rem;color:#888;font-weight:600;margin-bottom:.1rem}
 .chip{display:inline-flex;align-items:center;padding:.25rem .7rem;border-radius:16px;font-size:.78rem;cursor:pointer;border:1.5px solid #bbb;background:#fff;color:#555;transition:all .15s;user-select:none}
 .chip:hover{border-color:#888}
 .chip.active{background:#1976d2;color:#fff;border-color:#1976d2}
 .chip .chip-count{margin-left:.3rem;opacity:.7;font-size:.7rem}
+.chip .chip-rate{margin-left:.35rem;font-size:.68rem;opacity:.6;font-variant-numeric:tabular-nums}
 .btn-details{background:none;border:1px solid #bbb;border-radius:4px;padding:.15rem .4rem;font-size:.75rem;cursor:pointer;color:#666;white-space:nowrap}
 .btn-details:hover{border-color:#1976d2;color:#1976d2;background:#e3f2fd}
 .btn-preview{background:none;border:1px solid #bbb;border-radius:4px;padding:.15rem .4rem;font-size:.75rem;cursor:pointer;color:#666;white-space:nowrap}
@@ -823,6 +829,9 @@ body.dark .filter-label{color:#aaa}
 body.dark .filter-chart{border-top-color:#2a2a2a}
 body.dark .hbar-track{background:#333}
 body.dark .hbar-amt{color:#aaa}
+body.dark .hbar-pln{color:#666}
+body.dark .hbar-summary{color:#888;border-top-color:#333}
+body.dark .hbar-summary b{color:#bbb}
 body.dark .hbar-chart-title{color:#666}
 body.dark .chip{background:#2a2a2a;border-color:#555;color:#ccc}
 body.dark .chip:hover{border-color:#888}
@@ -1258,6 +1267,8 @@ const profileBadges = {}; // profileName → unread new-invoice count for dropdo
 let knownInvoiceKsefNumbers = null; // null = not yet baselined; Set after first search
 let lastSearchParams = null;        // params of last successful search; null = no search yet
 let showIncomeChart = true;         // opt-out pref — read from /prefs on load
+let fxRates = {};                   // { EUR: 4.25, HUF: 0.011, ... } — PLN per 1 unit, fetched from NBP
+let fxRatesFetchedAt = 0;           // epoch ms of last successful fetch
 
 // Set default month to current month and keep Od/Do consistent
 (function initDates() {
@@ -1309,6 +1320,7 @@ async function loadCachedInvoices() {
       knownInvoiceKsefNumbers = new Set(invoices.map(i => i.ksefNumber));
     }
     buildCurrencyFilter();
+    refreshExchangeRates(); // async — re-renders chart with PLN equivalents when rates arrive
     displayAll = false;
     currentPage = 0;
     renderTable();
@@ -1910,6 +1922,27 @@ function fmtAmt(v) {
   return v.toLocaleString('pl-PL', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
+// Fetches daily average exchange rates from NBP Table A (CORS-open public API).
+// Caches for 1 hour — NBP rates are updated once per business day.
+// On success re-renders the currency filter bar so PLN equivalents appear without a page reload.
+async function refreshExchangeRates() {
+  if (Date.now() - fxRatesFetchedAt < 3_600_000) { return; }
+  try {
+    const res = await fetch('https://api.nbp.pl/api/exchangerates/tables/A/?format=json', { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) { return; }
+    const data = await res.json();
+    const updated = {};
+    for (const rate of data[0].rates) { updated[rate.code] = rate.mid; }
+    updated['PLN'] = 1;
+    fxRates = updated;
+    fxRatesFetchedAt = Date.now();
+    console.log('[FX] NBP rates refreshed:', Object.keys(fxRates).length, 'currencies, effective', data[0].effectiveDate);
+    buildCurrencyFilter(); // re-render so PLN equivalents appear immediately
+  } catch (e) {
+    console.warn('[FX] NBP rate fetch failed:', e.message);
+  }
+}
+
 function buildCurrencyFilter() {
   const counts = {}, netTotals = {}, vatTotals = {};
   for (const inv of invoices) {
@@ -1941,7 +1974,8 @@ function buildCurrencyFilter() {
     html += '<div class="filter-chips-row"><span class="filter-label">Waluta:</span>';
     for (const c of currencies) {
       const active = activeCurrencies.has(c) ? ' active' : '';
-      html += '<span class="chip' + active + '" onclick="toggleCurrency(\'' + c + '\')">' + c + '<span class="chip-count">(' + counts[c] + ')</span></span>';
+      const rate = c !== 'PLN' && fxRates[c] ? '<span class="chip-rate">' + fxRates[c].toFixed(4) + '</span>' : '';
+      html += '<span class="chip' + active + '" onclick="toggleCurrency(\'' + c + '\')">' + c + '<span class="chip-count">(' + counts[c] + ')</span>' + rate + '</span>';
     }
     html += '</div>';
   }
@@ -1974,10 +2008,33 @@ function buildCurrencyFilter() {
           '<div class="hbar-fill" style="width:' + netPct + '%;flex-shrink:0;background:' + color + '"></div>' +
           (vat > 0 ? '<div class="hbar-fill" style="' + vatStyle + '"></div>' : '') +
         '</div>' +
-        '<span class="hbar-amt">' + fmtAmt(net) + ' + ' + fmtAmt(vat) + ' VAT</span>' +
+        '<span class="hbar-amt">' + fmtAmt(net) + ' + ' + fmtAmt(vat) + ' VAT' +
+          (cur !== 'PLN' && fxRates[cur] ? ' <span class="hbar-pln">≈ netto: ' + fmtAmt(net * fxRates[cur]) + ' / brutto: ' + fmtAmt(gross * fxRates[cur]) + ' PLN</span>' : '') +
+        '</span>' +
         '</div>';
     });
-    html += '<div class="filter-chart"><div class="hbar-chart-title">' + chartTitle + '</div>' + barsHtml + '</div>';
+
+    // Summary row — totals in PLN for selected currencies (all when no filter active)
+    const summaryEntries = entries.filter(([c]) => activeCurrencies.size === 0 || activeCurrencies.has(c));
+    let totalNetPln = 0, totalGrossPln = 0, missingRate = false, hasNonPln = false;
+    for (const [c, net] of summaryEntries) {
+      const vat = vatTotals[c] || 0;
+      const rate = c === 'PLN' ? 1 : (fxRates[c] || null);
+      if (c !== 'PLN') { hasNonPln = true; }
+      if (rate == null) { missingRate = true; continue; }
+      totalNetPln += net * rate;
+      totalGrossPln += (net + vat) * rate;
+    }
+    let summaryHtml = '';
+    if (hasNonPln && Object.keys(fxRates).length === 0) {
+      summaryHtml = '<div class="hbar-summary hbar-summary-wait">Oczekiwanie na kursy NBP…</div>';
+    } else if (summaryEntries.length > 0) {
+      const prefix = hasNonPln ? '~ ' : '';
+      const missing = missingRate ? ' <span class="hbar-summary-warn">(brak kursu dla niektórych walut)</span>' : '';
+      summaryHtml = '<div class="hbar-summary">' + prefix + 'łącznie netto: <b>' + fmtAmt(totalNetPln) + ' PLN</b>'
+        + ' / brutto: <b>' + fmtAmt(totalGrossPln) + ' PLN</b>' + missing + '</div>';
+    }
+    html += '<div class="filter-chart"><div class="hbar-chart-title">' + chartTitle + '</div>' + barsHtml + summaryHtml + '</div>';
   }
 
   filterBar.innerHTML = html;
@@ -2007,13 +2064,16 @@ function renderTable() {
     {key:'issueDate', label:'Data wystawienia'},
     {key:'sellerName', label:'Sprzedawca'},
     {key:'buyerName', label:'Nabywca'},
+    {key:'netAmount', label:'Kwota netto', cls:'amount'},
+    {key:'_vat', label:'VAT', cls:'amount'},
     {key:'grossAmount', label:'Kwota brutto', cls:'amount'},
     {key:'currency', label:'Waluta'},
   ];
   let sorted = [...getFilteredInvoices()];
   if (sortCol !== null) {
     sorted.sort((a,b) => {
-      let va = a[sortCol] ?? '', vb = b[sortCol] ?? '';
+      let va = sortCol === '_vat' ? ((a.grossAmount ?? 0) - (a.netAmount ?? 0)) : (a[sortCol] ?? '');
+      let vb = sortCol === '_vat' ? ((b.grossAmount ?? 0) - (b.netAmount ?? 0)) : (b[sortCol] ?? '');
       if (typeof va === 'number' && typeof vb === 'number') return sortAsc ? va - vb : vb - va;
       va = String(va).toLowerCase(); vb = String(vb).toLowerCase();
       return sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
@@ -2056,6 +2116,9 @@ function renderTable() {
     html += '<td>' + date + '</td>';
     html += '<td class="col-name" title="NIP: ' + (inv.sellerNip||'') + '">' + (inv.sellerName||'') + '</td>';
     html += '<td class="col-name">' + (inv.buyerName||'') + '</td>';
+    const vat = (inv.grossAmount != null && inv.netAmount != null) ? inv.grossAmount - inv.netAmount : null;
+    html += '<td class="amount">' + (inv.netAmount != null ? inv.netAmount.toFixed(2) : '') + '</td>';
+    html += '<td class="amount">' + (vat != null ? vat.toFixed(2) : '') + '</td>';
     html += '<td class="amount">' + (inv.grossAmount != null ? inv.grossAmount.toFixed(2) : '') + '</td>';
     html += '<td>' + (inv.currency||'') + '</td>';
     html += '</tr>';
@@ -2347,6 +2410,7 @@ async function doSearch() {
       setStatus('Znaleziono ' + total + ' faktur.', total > 0 ? 'info' : 'idle');
     }
     buildCurrencyFilter();
+    refreshExchangeRates(); // async — re-renders chart with PLN equivalents when rates arrive
     displayAll = false;
     currentPage = 0;
     renderTable();

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -1986,27 +1986,31 @@ function buildCurrencyFilter() {
     const chartTitles = { Subject1: 'Przychody netto + VAT', Subject2: 'Koszty netto + VAT', Subject3: 'Kwoty netto + VAT', SubjectAuthorized: 'Kwoty netto + VAT' };
     const chartTitle = chartTitles[subj] || 'Kwoty netto + VAT';
     const entries = Object.entries(netTotals).sort((a, b) => b[1] - a[1]);
-    // Scale against the largest gross (net+vat) so the widest bar fills 100% without clipping its own VAT segment
-    const maxVal = Math.max(...entries.map(([c, v]) => v + (vatTotals[c] || 0)), 1);
+    // Scale against the largest absolute gross so positive and negative bars share the same axis
+    const maxVal = Math.max(...entries.map(([c, v]) => Math.abs(v + (vatTotals[c] || 0))), 1);
     // Assign consistent colors by alphabetical currency order so chips and bars share a color
     const colorMap = {};
     currencies.forEach((c, i) => { colorMap[c] = CHART_PALETTE[i % CHART_PALETTE.length]; });
+    const MIN_PCT = 2; // minimum bar width so tiny values are always visible
     let barsHtml = '';
     entries.forEach(([cur, net]) => {
       const vat = vatTotals[cur] || 0;
       const gross = net + vat;
-      const netPct = Math.max(2, (net / maxVal) * 100);
-      // Compute VAT relative to rendered netPct (not maxVal) so the ratio is preserved when netPct is clamped.
-      // Clamp combined width to 100% as a defensive guard against extreme VAT ratios.
-      const vatPct = net > 0 ? Math.min((vat / net) * netPct, 100 - netPct) : 0;
+      const isNeg = net < 0;
+      const absNet = Math.abs(net);
+      const absVat = Math.abs(vat);
       const color = colorMap[cur] || CHART_PALETTE[0];
+      // Negative net (corrections dominate): render muted bar, label shows sign
+      const barColor = isNeg ? '#ef9a9a' : color; // red-200 for net-negative currencies
+      const netPct = Math.max(MIN_PCT, (absNet / maxVal) * 100);
+      const vatPct = absNet > 0 ? Math.min((absVat / absNet) * netPct, 100 - netPct) : 0;
       const tooltip = cur + ': netto ' + fmtAmt(net) + ', VAT ' + fmtAmt(vat) + ', brutto ' + fmtAmt(gross);
       const vatStyle = 'width:' + vatPct + '%;flex-shrink:0;background:' + VAT_COLOR;
       barsHtml += '<div class="hbar-row" title="' + tooltip + '">' +
         '<span class="hbar-cur" style="color:' + color + '">' + cur + '</span>' +
         '<div class="hbar-track">' +
-          '<div class="hbar-fill" style="width:' + netPct + '%;flex-shrink:0;background:' + color + '"></div>' +
-          (vat > 0 ? '<div class="hbar-fill" style="' + vatStyle + '"></div>' : '') +
+          '<div class="hbar-fill" style="width:' + netPct + '%;flex-shrink:0;background:' + barColor + '"></div>' +
+          (absVat > 0 ? '<div class="hbar-fill" style="' + vatStyle + '"></div>' : '') +
         '</div>' +
         '<span class="hbar-amt">' + fmtAmt(net) + ' + ' + fmtAmt(vat) + ' VAT' +
           (cur !== 'PLN' && fxRates[cur] ? ' <span class="hbar-pln">≈ netto: ' + fmtAmt(net * fxRates[cur]) + ' / brutto: ' + fmtAmt(gross * fxRates[cur]) + ' PLN</span>' : '') +

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2020,7 +2020,7 @@ function buildCurrencyFilter() {
 
     // Summary row — totals in PLN for selected currencies (all when no filter active)
     const summaryEntries = entries.filter(([c]) => activeCurrencies.size === 0 || activeCurrencies.has(c));
-    let totalNetPln = 0, totalGrossPln = 0, missingRate = false, hasNonPln = false;
+    let totalNetPln = 0, totalGrossPln = 0, missingRate = false, hasNonPln = false, convertedAny = false;
     for (const [c, net] of summaryEntries) {
       const vat = vatTotals[c] || 0;
       const rate = c === 'PLN' ? 1 : (fxRates[c] || null);
@@ -2028,9 +2028,10 @@ function buildCurrencyFilter() {
       if (rate == null) { missingRate = true; continue; }
       totalNetPln += net * rate;
       totalGrossPln += (net + vat) * rate;
+      convertedAny = true;
     }
     let summaryHtml = '';
-    const allRatesMissing = hasNonPln && missingRate && totalNetPln === 0 && totalGrossPln === 0;
+    const allRatesMissing = hasNonPln && missingRate && !convertedAny;
     if (hasNonPln && Object.keys(fxRates).length === 0) {
       summaryHtml = '<div class="hbar-summary hbar-summary-wait">Oczekiwanie na kursy NBP…</div>';
     } else if (allRatesMissing) {


### PR DESCRIPTION
- Currency chips now show live NBP exchange rates (Table A, cached 1h)
- Chart bars split into net (coloured) + VAT (grey) segments
- Bar labels and PLN summary show approximate net/gross in PLN
- PLN summary reacts to active currency filter; `~` prefix for foreign currencies
- Invoice table gets sortable net and VAT columns
- CSV export adds net amount column alongside gross
- Docs updated with changelog entries for 0.6.0 and 0.6.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Income/cost chart with stacked net+VAT bars, currency chips that filter chart/list and optionally show per-unit FX; PLN conversion via NBP with cached rates and PLN totals/approximation display; sortable "Kwota netto" and "VAT" columns in invoices; negative-value styling and minimum bar sizing.

* **Documentation**
  * README rebranded to ksef-gui; CSV monthly summary adds "Kwota netto" and clarifies gross amounts per invoice currency; expanded PDF field-mapping docs and new changelog entries.

* **Tests**
  * Updated VAT parsing expectations for revised exemption code handling.

* **Bug Fixes**
  * Clarified pagination semantics in API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->