### PR TITLE
feat: save downloads in subject-type subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.2] — unreleased
+## [0.6.2] — 2026-05-02
 
 ### ⚠️ Breaking Changes
 
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.6.1] — 2025-05-02
+## [0.6.1] — 2026-04-30
 
 ### Added
 - NBP exchange rate integration: currency chips show live mid-rate from NBP Table A (1 h cache)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to this project will be documented in this file.
   - `output-dir/nabywca/` — Subject2, no NIP separation
   - `output-dir/NIP/sprzedawca/` — Subject1, with NIP separation
   - `output-dir/NIP/nabywca/` — Subject2, with NIP separation
-  - `output-dir/NIP/podmiot3/` — Subject3
-  - `output-dir/NIP/uprawniony/` — SubjectAuthorized
+  - `output-dir/podmiot3/` or `output-dir/NIP/podmiot3/` — Subject3
+  - `output-dir/uprawniony/` or `output-dir/NIP/uprawniony/` — SubjectAuthorized
 
   Existing downloaded files will not be detected as present (table icons will be missing) until moved to the new subfolder or re-downloaded. Preferences are migrated automatically on first start.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### ⚠️ Breaking Changes
 
-- **Download directory structure changed.** Invoices are now saved to a subject-type subfolder: `output-dir/[NIP/]sprzedawca|nabywca|podmiot3|uprawniony/`. Previously files landed directly in `output-dir/` or `output-dir/NIP/`. Existing downloaded files will not be detected as present (table icons will be missing) until moved to the new subfolder or re-downloaded.
+- **Download directory structure changed.** Invoices are now saved to a subject-type subfolder. Previously files landed directly in `output-dir/` or `output-dir/NIP/`. The new layout:
+  - `output-dir/sprzedawca/` — Subject1, no NIP separation
+  - `output-dir/nabywca/` — Subject2, no NIP separation
+  - `output-dir/NIP/sprzedawca/` — Subject1, with NIP separation
+  - `output-dir/NIP/nabywca/` — Subject2, with NIP separation
+  - `output-dir/NIP/podmiot3/` — Subject3
+  - `output-dir/NIP/uprawniony/` — SubjectAuthorized
+
+  Existing downloaded files will not be detected as present (table icons will be missing) until moved to the new subfolder or re-downloaded. Preferences are migrated automatically on first start.
 
 ### Added
-- Save path now includes subject-type subfolder: `outputDir/[NIP/]sprzedawca|nabywca|podmiot3|uprawniony/`
+- Save path now includes a subject-type subfolder (`sprzedawca`, `nabywca`, `podmiot3`, or `uprawniony`) appended after the optional NIP segment
+- Automatic prefs migration on startup: strips legacy NIP/subject-type segments from stored `OutputDir`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.6.0] — 2025-04-09
+## [0.6.0] — 2026-04-17
 
 ### Added
 - Horizontal bar chart showing net totals per currency (opt-out in Preferences)
@@ -58,14 +58,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.5.9] — 2025-04-07
+## [0.5.9] — 2026-04-16
 
 ### Changed
 - Renamed `offset` variable to `pageNumber` to reflect correct KSeF API semantics
 
 ---
 
-## [0.5.8] — 2025-04-06
+## [0.5.8] — 2026-04-16
 
 ### Fixed
 - Handle KSeF error 21405 (page offset out of range) with user-friendly warning
@@ -73,14 +73,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.5.7] — 2025-04-04
+## [0.5.7] — 2026-04-16
 
 ### Changed
 - Bumped all GitHub Actions to latest versions
 
 ---
 
-## [0.5.6] — 2025-03-31
+## [0.5.6] — 2026-04-16
 
 ### Added
 - Toast notifications for search results and background events
@@ -88,35 +88,35 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.5.5] — 2025-03-28
+## [0.5.5] — 2026-04-15
 
 ### Added
 - KSeF API 10 000-result limit detection with truncation warning and UI message
 
 ---
 
-## [0.5.4] — 2025-03-25
+## [0.5.4] — 2026-04-15
 
 ### Fixed
 - Active profile cache now syncs correctly after background refresh
 
 ---
 
-## [0.5.3] — 2025-03-22
+## [0.5.3] — 2026-03-31
 
 ### Fixed
 - Prevent double notifications for the active profile during background refresh
 
 ---
 
-## [0.5.2] — 2025-03-19
+## [0.5.2] — 2026-03-12
 
 ### Added
 - Monthly invoice summary CSV export (UTF-8 BOM, `;` separator, per-currency totals)
 
 ---
 
-## [0.5.1] — 2025-03-15
+## [0.5.1] — 2026-03-05
 
 ### Fixed
 - Font rendering improvements in PDF output
@@ -124,7 +124,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.5.0] — 2025-03-12
+## [0.5.0] — 2026-03-05
 
 ### Added
 - KSeF reference number displayed in PDF (injected from API response, not XML)
@@ -132,35 +132,35 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.4.2] — 2025-03-08
+## [0.4.2] — 2026-03-03
 
 ### Added
 - Retry mechanism for failed webhook/email notifications with persistent queue
 
 ---
 
-## [0.4.1] — 2025-03-05
+## [0.4.1] — 2026-03-02
 
 ### Fixed
 - Token handling improvements: correct refresh timing and expiry logic
 
 ---
 
-## [0.4.0] — 2025-03-02
+## [0.4.0] — 2026-03-01
 
 ### Added
 - Auto-refresh date range controls per profile (limit to current month option)
 
 ---
 
-## [0.3.9] — 2025-02-26
+## [0.3.9] — 2026-02-26
 
 ### Fixed
 - Escape special Markdown characters in Slack notification messages
 
 ---
 
-## [0.3.8] — 2025-02-24
+## [0.3.8] — 2026-02-25
 
 ### Added
 - SMTP e-mail notifications (STARTTLS, port 587) per profile
@@ -168,56 +168,56 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.3.7] — 2025-02-20
+## [0.3.7] — 2026-02-24
 
 ### Changed
 - Improved token management flow: proactive expiry, single refresh path
 
 ---
 
-## [0.3.6] — 2025-02-18
+## [0.3.6] — 2026-02-24
 
 ### Fixed
 - Preferences modal UX: data loss on cancel prevented, validation improved
 
 ---
 
-## [0.3.5] — 2025-02-16
+## [0.3.5] — 2026-02-24
 
 ### Added
 - Webhook notifications documentation
 
 ---
 
-## [0.3.4] — 2025-02-13
+## [0.3.4] — 2026-02-19
 
 ### Fixed
 - Path traversal vulnerability in file serving endpoint
 
 ---
 
-## [0.3.3] — 2025-02-11
+## [0.3.3] — 2026-02-19
 
 ### Changed
 - Improved profile deletion UX with confirmation dialog
 
 ---
 
-## [0.3.2] — 2025-02-09
+## [0.3.2] — 2026-02-18
 
 ### Added
 - Docker image published to GitHub Container Registry (GHCR)
 
 ---
 
-## [0.3.1] — 2025-02-06
+## [0.3.1] — 2026-02-16
 
 ### Added
 - Comprehensive invoice XML security validation (XSD, element limits, size cap)
 
 ---
 
-## [0.3.0] — 2025-02-04
+## [0.3.0] — 2026-02-16
 
 ### Added
 - SQLite invoice cache with background auto-refresh every N minutes
@@ -226,63 +226,63 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.2.7] — 2025-01-30
+## [0.2.7] — 2026-02-14
 
 ### Changed
 - Test infrastructure improvements, code quality fixes
 
 ---
 
-## [0.2.6] — 2025-01-28
+## [0.2.6] — 2026-02-14
 
 ### Fixed
 - 100 unit tests passing; exposed internals for testing; corrected routes, exception types, sanitization
 
 ---
 
-## [0.2.5] — 2025-01-24
+## [0.2.5] — 2026-02-14
 
 ### Added
 - Docker production stack with Traefik reverse proxy and Ofelia scheduler
 
 ---
 
-## [0.2.4] — 2025-01-21
+## [0.2.4] — 2026-02-13
 
 ### Changed
 - Improved logging, documentation, privacy handling (no PII in logs)
 
 ---
 
-## [0.2.3] — 2025-01-18
+## [0.2.3] — 2026-02-13
 
 ### Changed
 - Improved logging and localization for GUI interface
 
 ---
 
-## [0.2.2] — 2025-01-15
+## [0.2.2] — 2026-02-12
 
 ### Changed
 - Removed unused submodules (ksef-docs, ksef-pdf-generator)
 
 ---
 
-## [0.2.1] — 2025-01-14
+## [0.2.1] — 2026-02-12
 
 ### Fixed
 - Release workflow trigger: match non-`v`-prefixed tags
 
 ---
 
-## [0.2.0] — 2025-01-12
+## [0.2.0] — 2026-02-12
 
 ### Changed
 - Replaced external Node.js PDF generator with native QuestPDF renderer (no external dependencies)
 
 ---
 
-## [0.1.4] — 2025-01-09
+## [0.1.4] — 2026-02-12
 
 ### Fixed
 - Cache corruption prevention on profile switch failure
@@ -290,21 +290,21 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.1.3] — 2025-01-07
+## [0.1.3] — 2026-02-10
 
 ### Fixed
 - PDF generation error handling on Windows
 
 ---
 
-## [0.1.2] — 2025-01-06
+## [0.1.2] — 2026-02-10
 
 ### Fixed
 - Node.js path parsing on Windows
 
 ---
 
-## [0.1.1] — 2025-01-05
+## [0.1.1] — 2026-02-10
 
 ### Fixed
 - Resource leaks in scope recreation
@@ -312,7 +312,7 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## [0.1.0] — 2025-01-04
+## [0.1.0] — 2026-02-10
 
 ### Added
 - Initial public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,323 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.6.2] — unreleased
+
+### ⚠️ Breaking Changes
+
+- **Download directory structure changed.** Invoices are now saved to a subject-type subfolder: `output-dir/[NIP/]sprzedawca|nabywca|podmiot3|uprawniony/`. Previously files landed directly in `output-dir/` or `output-dir/NIP/`. Existing downloaded files will not be detected as present (table icons will be missing) until moved to the new subfolder or re-downloaded.
+
+### Added
+- Save path now includes subject-type subfolder: `outputDir/[NIP/]sprzedawca|nabywca|podmiot3|uprawniony/`
+
+---
+
+## [0.6.1] — 2025-05-02
+
+### Added
+- NBP exchange rate integration: currency chips show live mid-rate from NBP Table A (1 h cache)
+- PLN conversion in bar chart labels: `≈ netto: X PLN / brutto: Y PLN` per currency
+- PLN summary row below chart, reactive to active currency filter; `~` prefix for approximate values
+- Net+VAT stacked bars: coloured net segment + grey VAT segment, proportionally scaled against largest gross
+- `Podmiot3` (third party) and `PodmiotUpowazniony` (authorised entity) rendered in PDF
+- Dynamic VAT rate discovery: all `P_13_*` / `P_14_*` fields scanned automatically — no hardcoded rate list
+- `P_14_*W` column in VAT table (foreign-currency VAT), shown only when present
+- `P_KursWaluty` — invoice-level exchange rate in PDF Details section
+- `P_16` (reverse charge), `P_17` (self-billing), `P_18` (margin scheme), `P_18A` (new transport) — highlighted annotations in PDF
+- `P_19` / `P_19A` / `P_19B` — VAT exemption basis, legal reference, description in PDF
+- `WarunkiTransakcji`: `NrZamowienia`, `NrPartiiDostawy`, `Incoterms` in PDF
+- Invoice table columns: **Kwota netto** and **VAT** (`brutto − netto`) alongside Kwota brutto — all sortable
+- NBP FX fetch state flags: separate `fxRatesFetchInProgress` / `fxRatesFetchFailed` — summary shows correct message per state
+
+### Fixed
+- Chart proportionality: VAT segment scales relative to rendered net bar, preserving ratio for clamped small currencies
+- Correction invoices (negative net) render muted red bar; no fake net segment when net = 0
+- VAT table brutto uses `P_14_*W` (invoice currency) instead of PLN VAT for foreign-currency invoices
+- `SavePrefs` always stores base output directory, preventing path duplication on repeated downloads
+- PLN summary no longer shows `0 PLN` when all selected non-PLN currencies lack exchange rates
+- VAT sort column treats missing amounts as `null` (sorts separately) rather than `0`
+- `silentRefresh` now triggers `refreshExchangeRates` so PLN conversions stay fresh in background
+
+### Changed
+- Chart title is dynamic: *Przychody* for Subject1, *Koszty* for Subject2, *Kwoty* for others
+- Bars scale against max gross so the largest bar fills 100% without clipping its VAT segment
+- VAT rows ordered numerically by suffix (`P_13_10` after `P_13_9`, not before `P_13_2`)
+- P_13_7 correctly mapped to `np` (niepodlegający), not `zw` (zwolniony = P_13_6)
+- Correction invoices now symmetrically reduce both `netTotals` and `vatTotals`
+- VAT table PLN column header is `VAT (PLN)` when foreign-currency VAT column is also present
+
+---
+
+## [0.6.0] — 2025-04-09
+
+### Added
+- Horizontal bar chart showing net totals per currency (opt-out in Preferences)
+- VAT segment in currency bars (grey, proportional)
+- Dynamic chart title based on subject type
+
+---
+
+## [0.5.9] — 2025-04-07
+
+### Changed
+- Renamed `offset` variable to `pageNumber` to reflect correct KSeF API semantics
+
+---
+
+## [0.5.8] — 2025-04-06
+
+### Fixed
+- Handle KSeF error 21405 (page offset out of range) with user-friendly warning
+- Improved error UX for API limit errors
+
+---
+
+## [0.5.7] — 2025-04-04
+
+### Changed
+- Bumped all GitHub Actions to latest versions
+
+---
+
+## [0.5.6] — 2025-03-31
+
+### Added
+- Toast notifications for search results and background events
+- Income chart (net per currency) in the filter bar
+
+---
+
+## [0.5.5] — 2025-03-28
+
+### Added
+- KSeF API 10 000-result limit detection with truncation warning and UI message
+
+---
+
+## [0.5.4] — 2025-03-25
+
+### Fixed
+- Active profile cache now syncs correctly after background refresh
+
+---
+
+## [0.5.3] — 2025-03-22
+
+### Fixed
+- Prevent double notifications for the active profile during background refresh
+
+---
+
+## [0.5.2] — 2025-03-19
+
+### Added
+- Monthly invoice summary CSV export (UTF-8 BOM, `;` separator, per-currency totals)
+
+---
+
+## [0.5.1] — 2025-03-15
+
+### Fixed
+- Font rendering improvements in PDF output
+- Better error handling for malformed XML invoices
+
+---
+
+## [0.5.0] — 2025-03-12
+
+### Added
+- KSeF reference number displayed in PDF (injected from API response, not XML)
+- QR code (KOD I) in PDF: `https://qr.ksef.mf.gov.pl/invoice/{nip}/{date}/{hash}`
+
+---
+
+## [0.4.2] — 2025-03-08
+
+### Added
+- Retry mechanism for failed webhook/email notifications with persistent queue
+
+---
+
+## [0.4.1] — 2025-03-05
+
+### Fixed
+- Token handling improvements: correct refresh timing and expiry logic
+
+---
+
+## [0.4.0] — 2025-03-02
+
+### Added
+- Auto-refresh date range controls per profile (limit to current month option)
+
+---
+
+## [0.3.9] — 2025-02-26
+
+### Fixed
+- Escape special Markdown characters in Slack notification messages
+
+---
+
+## [0.3.8] — 2025-02-24
+
+### Added
+- SMTP e-mail notifications (STARTTLS, port 587) per profile
+- Extended notifications with invoice details (date, NIP, seller name)
+
+---
+
+## [0.3.7] — 2025-02-20
+
+### Changed
+- Improved token management flow: proactive expiry, single refresh path
+
+---
+
+## [0.3.6] — 2025-02-18
+
+### Fixed
+- Preferences modal UX: data loss on cancel prevented, validation improved
+
+---
+
+## [0.3.5] — 2025-02-16
+
+### Added
+- Webhook notifications documentation
+
+---
+
+## [0.3.4] — 2025-02-13
+
+### Fixed
+- Path traversal vulnerability in file serving endpoint
+
+---
+
+## [0.3.3] — 2025-02-11
+
+### Changed
+- Improved profile deletion UX with confirmation dialog
+
+---
+
+## [0.3.2] — 2025-02-09
+
+### Added
+- Docker image published to GitHub Container Registry (GHCR)
+
+---
+
+## [0.3.1] — 2025-02-06
+
+### Added
+- Comprehensive invoice XML security validation (XSD, element limits, size cap)
+
+---
+
+## [0.3.0] — 2025-02-04
+
+### Added
+- SQLite invoice cache with background auto-refresh every N minutes
+- Per-profile opt-in for background refresh
+- OS desktop notifications, Slack and Teams webhook notifications
+
+---
+
+## [0.2.7] — 2025-01-30
+
+### Changed
+- Test infrastructure improvements, code quality fixes
+
+---
+
+## [0.2.6] — 2025-01-28
+
+### Fixed
+- 100 unit tests passing; exposed internals for testing; corrected routes, exception types, sanitization
+
+---
+
+## [0.2.5] — 2025-01-24
+
+### Added
+- Docker production stack with Traefik reverse proxy and Ofelia scheduler
+
+---
+
+## [0.2.4] — 2025-01-21
+
+### Changed
+- Improved logging, documentation, privacy handling (no PII in logs)
+
+---
+
+## [0.2.3] — 2025-01-18
+
+### Changed
+- Improved logging and localization for GUI interface
+
+---
+
+## [0.2.2] — 2025-01-15
+
+### Changed
+- Removed unused submodules (ksef-docs, ksef-pdf-generator)
+
+---
+
+## [0.2.1] — 2025-01-14
+
+### Fixed
+- Release workflow trigger: match non-`v`-prefixed tags
+
+---
+
+## [0.2.0] — 2025-01-12
+
+### Changed
+- Replaced external Node.js PDF generator with native QuestPDF renderer (no external dependencies)
+
+---
+
+## [0.1.4] — 2025-01-09
+
+### Fixed
+- Cache corruption prevention on profile switch failure
+- Profile rollback on switch error
+
+---
+
+## [0.1.3] — 2025-01-07
+
+### Fixed
+- PDF generation error handling on Windows
+
+---
+
+## [0.1.2] — 2025-01-06
+
+### Fixed
+- Node.js path parsing on Windows
+
+---
+
+## [0.1.1] — 2025-01-05
+
+### Fixed
+- Resource leaks in scope recreation
+- GUI config error handling improvements
+
+---
+
+## [0.1.0] — 2025-01-04
+
+### Added
+- Initial public release
+- Browser-based GUI with embedded HTTP server
+- Multi-profile support with YAML configuration
+- Certificate-based authentication
+- CI/CD workflows (GitHub Actions), build metadata injection
+- Windows, Linux, macOS builds

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ Token długoterminowy: portal KSeF → _Integracja → Tokeny_.
 | `--useInvoiceNumber` | Nazwa pliku wg numeru faktury        | wyłączone |
 | `--lan`              | Nasłuchuj na wszystkich interfejsach | wyłączone |
 
+### 📁 Struktura katalogów przy pobieraniu
+
+Faktury zapisywane są według schematu zależnego od ustawień:
+
+| Oddziel po NIP | Typ podmiotu | Ścieżka |
+| :------------: | ------------ | ------- |
+| ✗ | — | `katalog-wyjściowy/` |
+| ✗ | Subject1 | `katalog-wyjściowy/sprzedawca/` |
+| ✗ | Subject2 | `katalog-wyjściowy/nabywca/` |
+| ✓ | Subject1 | `katalog-wyjściowy/NIP/sprzedawca/` |
+| ✓ | Subject2 | `katalog-wyjściowy/NIP/nabywca/` |
+| ✓ | Subject3 | `katalog-wyjściowy/NIP/podmiot3/` |
+| ✓ | SubjectAuthorized | `katalog-wyjściowy/NIP/uprawniony/` |
+
+> ⚠️ **Breaking change (0.6.2):** W poprzednich wersjach faktury trafiały bezpośrednio do `katalog-wyjściowy/` lub `katalog-wyjściowy/NIP/` bez podkatalogu typu podmiotu. Po aktualizacji pliki pobrane wcześniej nie będą widoczne jako już istniejące (ikony XML/PDF w tabeli) — należy je ręcznie przenieść do odpowiedniego podkatalogu lub ponownie pobrać.
+
 ### 📊 Podsumowanie miesięczne (CSV)
 
 Po wyszukaniu faktur przycisk **Podsumowanie CSV** (widoczny na pasku narzędzi obok przycisków pobierania) generuje zestawienie faktur za miesiąc wybrany w polu **Od**.
@@ -564,6 +580,22 @@ Obtain a long-term token from the KSeF portal: _Integracja → Tokeny_.
 | `--useInvoiceNumber` | Use invoice number for filenames |   off   |
 | `--lan`              | Listen on all network interfaces |   off   |
 
+### 📁 Download directory structure
+
+Invoices are saved according to a path scheme determined by settings:
+
+| Separate by NIP | Subject type | Path |
+| :-------------: | ------------ | ---- |
+| ✗ | — | `output-dir/` |
+| ✗ | Subject1 | `output-dir/sprzedawca/` |
+| ✗ | Subject2 | `output-dir/nabywca/` |
+| ✓ | Subject1 | `output-dir/NIP/sprzedawca/` |
+| ✓ | Subject2 | `output-dir/NIP/nabywca/` |
+| ✓ | Subject3 | `output-dir/NIP/podmiot3/` |
+| ✓ | SubjectAuthorized | `output-dir/NIP/uprawniony/` |
+
+> ⚠️ **Breaking change (0.6.2):** Previous versions saved invoices directly to `output-dir/` or `output-dir/NIP/` with no subject-type subfolder. After upgrading, previously downloaded files will no longer be detected as existing (XML/PDF icons will not appear in the table). Move existing files to the appropriate subfolder or re-download them.
+
 ### 📊 Monthly summary (CSV)
 
 After searching, the **Podsumowanie CSV** button (visible in the toolbar next to the download buttons) generates an invoice summary for the month selected in the **From** field.
@@ -826,33 +858,22 @@ Fields extracted from KSeF invoice XML (FA(3) schema) and included in the genera
 
 ## 📋 Changelog
 
+### 0.6.2 (unreleased)
+
+**⚠️ Breaking change — struktura katalogów**
+- Faktury zapisywane są teraz w podkatalogu według typu podmiotu: `katalog/[NIP/]sprzedawca|nabywca|podmiot3|uprawniony/`
+- Pliki pobrane we wcześniejszych wersjach nie będą rozpoznawane jako istniejące — należy je przenieść do odpowiedniego podkatalogu
+
+---
+
 ### 0.6.1
 
-**Wykres walut / Currency chart**
-- Słupki netto + VAT: każdy słupek składa się z części netto (kolor waluty) i VAT (szary), proporcjonalnie skalowanych
-- Poprawna kolejność kolumn w tabeli faktur: netto → VAT → brutto → waluta
-- Kurs walut NBP: chipy walutowe wyświetlają aktualny kurs (np. `EUR (12) 4,2567`), pobierany z publicznego API NBP (Tabela A, cache 1 h)
-- Przeliczenie na PLN: etykiety słupków pokazują przybliżone wartości `≈ netto: X PLN / brutto: Y PLN`
-- Podsumowanie w PLN pod wykresem, reaktywne na filtr walut; `~` dla walut obcych, wartość dokładna dla PLN
-- Dynamiczny tytuł wykresu: Przychody / Koszty / Kwoty w zależności od typu podmiotu
-- Poprawna obsługa faktur korygujących: kwota VAT prawidłowo korygowana w dół
-
-**Tabela faktur / Invoice table**
-- Nowe kolumny: Kwota netto i VAT (`brutto − netto`) obok Kwoty brutto — wszystkie sortowalne
-- Kolumna VAT obliczana w walucie faktury (nie PLN)
-
-**Poprawki API / API fixes**
-- Naprawiono błąd 21405: `pageOffset` to numer strony (0-based), nie offset rekordu — `currentPage++` zamiast `currentOffset += pageSize`
-
-**PDF — nowe pola FA(3)**
-- `Podmiot3` (podmiot trzeci) — osobny blok pod Sprzedawcą/Nabywcą
-- `PodmiotUpowazniony` — podmiot upoważniony do wystawiania faktur
-- Dynamiczne wykrywanie stawek VAT: skan wszystkich `P_13_*` / `P_14_*` zamiast hardcodowanej listy — obsługuje wszystkie stawki (23%, 8%, 5%, 3%, 0%, zw, np, oo i inne)
-- `P_14_*W` — VAT w walucie obcej jako dodatkowa kolumna w tabeli stawek
-- `P_KursWaluty` — kurs waluty całej faktury w sekcji Szczegóły
-- `P_16` (odwrotne obciążenie), `P_17` (samofakturowanie), `P_18` (procedura marży), `P_18A` (nowe środki transportu) — wyróżnione adnotacje
-- `P_19` / `P_19A` / `P_19B` — podstawa i przepis zwolnienia z VAT
-- `WarunkiTransakcji`: `NrZamowienia`, `NrPartiiDostawy`, `Incoterms`
+- Kursy walut NBP w chipach walutowych (np. `EUR (12) 4,2567`)
+- Przeliczenie na PLN w wykresie: `≈ netto: X PLN / brutto: Y PLN`
+- Podsumowanie w PLN pod wykresem, reaktywne na filtr walut
+- Słupki netto + VAT skalowane proporcjonalnie do największej wartości brutto
+- Nowe kolumny w tabeli faktur: Kwota netto i VAT (`brutto − netto`)
+- PDF: Podmiot3, PodmiotUpowazniony, dynamiczne stawki VAT (`P_13_*`/`P_14_*`), VAT walutowy (`P_14_*W`), kurs waluty, procedury specjalne (P_16–P_18A), podstawa zwolnienia (P_19), warunki transakcji (Incoterms, NrZamówienia)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -856,7 +856,7 @@ Fields extracted from KSeF invoice XML (FA(3) schema) and included in the genera
 
 ## 📋 Changelog
 
-### 0.6.2 (unreleased)
+### 0.6.2
 
 **⚠️ Breaking change — struktura katalogów**
 - Faktury zapisywane są teraz w podkatalogu według typu podmiotu: `katalog/[NIP/]sprzedawca|nabywca|podmiot3|uprawniony/`

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ Faktury zapisywane są według schematu zależnego od ustawień:
 
 | Oddziel po NIP | Typ podmiotu | Ścieżka |
 | :------------: | ------------ | ------- |
-| ✗ | — | `katalog-wyjściowy/` |
 | ✗ | Subject1 | `katalog-wyjściowy/sprzedawca/` |
 | ✗ | Subject2 | `katalog-wyjściowy/nabywca/` |
 | ✓ | Subject1 | `katalog-wyjściowy/NIP/sprzedawca/` |
@@ -586,7 +585,6 @@ Invoices are saved according to a path scheme determined by settings:
 
 | Separate by NIP | Subject type | Path |
 | :-------------: | ------------ | ---- |
-| ✗ | — | `output-dir/` |
 | ✗ | Subject1 | `output-dir/sprzedawca/` |
 | ✗ | Subject2 | `output-dir/nabywca/` |
 | ✓ | Subject1 | `output-dir/NIP/sprzedawca/` |

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -501,8 +501,13 @@ public class GuiCommand : IWithConfigCommand
                 string nip = Config().Nip;
                 if (!string.IsNullOrEmpty(nip))
                 {
-                    outputDir = Path.Combine(outputDir, nip);
+                    outputDir = Path.Join(outputDir, nip);
                 }
+            }
+            string checkSubjectFolder = SubjectTypeFolder(checkParams.SubjectType);
+            if (!string.IsNullOrEmpty(checkSubjectFolder))
+            {
+                outputDir = Path.Join(outputDir, checkSubjectFolder);
             }
 
             var result = _cachedInvoices.Select(inv =>
@@ -1944,14 +1949,20 @@ public class GuiCommand : IWithConfigCommand
             throw new InvalidOperationException("No invoices found. Search first.");
         }
 
-        string outputDir = string.IsNullOrWhiteSpace(dlParams.OutputDir) ? OutputDir : dlParams.OutputDir;
+        string baseOutputDir = string.IsNullOrWhiteSpace(dlParams.OutputDir) ? OutputDir : dlParams.OutputDir;
+        string outputDir = baseOutputDir;
         if (dlParams.SeparateByNip)
         {
             string nip = Config().Nip;
             if (!string.IsNullOrEmpty(nip))
             {
-                outputDir = Path.Combine(outputDir, nip);
+                outputDir = Path.Join(outputDir, nip);
             }
+        }
+        string subjectFolder = SubjectTypeFolder(dlParams.SubjectType);
+        if (!string.IsNullOrEmpty(subjectFolder))
+        {
+            outputDir = Path.Join(outputDir, subjectFolder);
         }
         Directory.CreateDirectory(outputDir);
 
@@ -2061,7 +2072,7 @@ public class GuiCommand : IWithConfigCommand
 
         SavePrefs(LoadPrefs() with
         {
-            OutputDir = dlParams.SeparateByNip ? Path.GetDirectoryName(outputDir) ?? outputDir : outputDir,
+            OutputDir = baseOutputDir,
             ExportXml = dlParams.ExportXml,
             ExportJson = dlParams.ExportJson,
             ExportPdf = wantPdf,
@@ -2088,6 +2099,15 @@ public class GuiCommand : IWithConfigCommand
         string ksef = inv.KsefNumber;
         return $"{date}-{seller}-{currency}-{ksef}";
     }
+
+    internal static string SubjectTypeFolder(string? subjectType) => subjectType?.ToLowerInvariant() switch
+    {
+        "subject1" or "1" => "sprzedawca",
+        "subject2" or "2" => "nabywca",
+        "subject3" or "3" => "podmiot3",
+        "subjectauthorized" or "4" => "uprawniony",
+        _ => string.Empty
+    };
 
     internal static string SanitizeFileName(string name)
     {

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -167,8 +167,9 @@ public class GuiCommand : IWithConfigCommand
                 // Log instead of silently swallowing: a JsonException here (e.g. from a partially
                 // written file) would cause every subsequent SavePrefs call to use an empty GuiPrefs
                 // as the base, wiping SMTP credentials and webhook URLs from disk.
-                return JsonSerializer.Deserialize<GuiPrefs>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                GuiPrefs loaded = JsonSerializer.Deserialize<GuiPrefs>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                     ?? new GuiPrefs();
+                return ApplyMigrations(loaded);
             }
             catch (IOException ex)
             {
@@ -184,6 +185,55 @@ public class GuiCommand : IWithConfigCommand
             }
         }
         return new GuiPrefs();
+    }
+
+    // Runs automatically on every prefs load. Add new migrations as new versions require them.
+    // Each migration must be idempotent — safe to run on already-migrated prefs.
+    private static GuiPrefs ApplyMigrations(GuiPrefs prefs)
+    {
+        bool changed = false;
+
+        // v0.6.2: OutputDir stored by old versions may contain a trailing NIP and/or subject-type
+        // segment appended by the old download logic. Strip them so the stored path is the clean
+        // user-chosen base directory, preventing double-appending on the next download.
+        if (!string.IsNullOrEmpty(prefs.OutputDir))
+        {
+            string stripped = StripLegacyOutputDirSegments(prefs.OutputDir);
+            if (stripped != prefs.OutputDir)
+            {
+                Log.LogInformation($"[prefs] Migration: OutputDir '{prefs.OutputDir}' → '{stripped}'");
+                prefs = prefs with { OutputDir = stripped };
+                changed = true;
+            }
+        }
+
+        if (changed)
+        {
+            SavePrefs(prefs);
+        }
+
+        return prefs;
+    }
+
+    private static string StripLegacyOutputDirSegments(string path)
+    {
+        string result = Path.GetFullPath(path);
+
+        // Strip trailing subject-type folder (e.g. /sprzedawca, /nabywca, /podmiot3, /uprawniony)
+        string lastName = Path.GetFileName(result);
+        if (lastName is "sprzedawca" or "nabywca" or "podmiot3" or "uprawniony")
+        {
+            result = Path.GetDirectoryName(result) ?? result;
+            lastName = Path.GetFileName(result);
+        }
+
+        // Strip trailing NIP segment (exactly 10 digits)
+        if (lastName.Length == 10 && lastName.All(char.IsDigit))
+        {
+            result = Path.GetDirectoryName(result) ?? result;
+        }
+
+        return result;
     }
 
     private static void SavePrefs(GuiPrefs prefs)

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -9,8 +9,8 @@ using KSeF.Client.Core.Exceptions;
 namespace KSeFCli;
 
 internal record SearchParams(string SubjectType, string From, string? To, string DateType, string? Source = null);
-internal record DownloadParams(string OutputDir, int[]? SelectedIndices, bool CustomFilenames, bool ExportXml = true, bool ExportJson = false, bool ExportPdf = true, bool SeparateByNip = false, string? PdfColorScheme = null);
-internal record CheckExistingParams(string OutputDir, bool CustomFilenames, bool SeparateByNip);
+internal record DownloadParams(string OutputDir, int[]? SelectedIndices, bool CustomFilenames, bool ExportXml = true, bool ExportJson = false, bool ExportPdf = true, bool SeparateByNip = false, string? PdfColorScheme = null, string? SubjectType = null);
+internal record CheckExistingParams(string OutputDir, bool CustomFilenames, bool SeparateByNip, string? SubjectType = null);
 internal record DownloadSummaryParams(string OutputDir, string Month, bool SeparateByNip = false);
 
 internal sealed class WebProgressServer : IDisposable
@@ -2644,7 +2644,8 @@ async function doDownload(selOnly) {
       exportJson: $('expJson').checked,
       exportPdf: $('expPdf').checked,
       separateByNip: $('separateByNip').checked,
-      pdfColorScheme: $('pdfColorScheme').value
+      pdfColorScheme: $('pdfColorScheme').value,
+      subjectType: $('subjectType') ? $('subjectType').value : null
     };
     const res = await fetch('/download', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
     if (!res.ok) { const e = await res.json(); throw new Error(e.error || 'Download failed'); }
@@ -2946,7 +2947,8 @@ async function checkExisting() {
     const body = {
       outputDir: $('outputDir').value || '.',
       customFilenames: $('customFilenames').checked,
-      separateByNip: $('separateByNip').checked
+      separateByNip: $('separateByNip').checked,
+      subjectType: $('subjectType') ? $('subjectType').value : null
     };
     const res = await fetch('/check-existing', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
     if (!res.ok) return;

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -248,7 +248,8 @@ internal sealed class WebProgressServer : IDisposable
         {
             await HandleAction(ctx, ct, async () =>
             {
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
                 if (OnSavePrefs != null)
                 {
                     await OnSavePrefs(body).ConfigureAwait(false);
@@ -279,7 +280,8 @@ internal sealed class WebProgressServer : IDisposable
                     throw new InvalidOperationException("Search not configured");
                 }
 
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
                 SearchParams searchParams = JsonSerializer.Deserialize<SearchParams>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                     ?? throw new InvalidOperationException("Invalid search parameters");
                 object result = await OnSearch(searchParams, ct).ConfigureAwait(false);
@@ -323,7 +325,8 @@ internal sealed class WebProgressServer : IDisposable
         {
             await HandleAction(ctx, ct, async () =>
             {
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
                 using JsonDocument doc = JsonDocument.Parse(body);
                 string dirPath = doc.RootElement.GetProperty("path").GetString()
                     ?? throw new InvalidOperationException("Missing path");
@@ -348,7 +351,8 @@ internal sealed class WebProgressServer : IDisposable
                     throw new InvalidOperationException("Download not configured");
                 }
 
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
                 DownloadParams dlParams = JsonSerializer.Deserialize<DownloadParams>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                     ?? new DownloadParams(".", null, false);
                 await OnDownload(dlParams, ct).ConfigureAwait(false);
@@ -364,7 +368,8 @@ internal sealed class WebProgressServer : IDisposable
                     throw new InvalidOperationException("Summary not configured");
                 }
 
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
                 DownloadSummaryParams sumParams = JsonSerializer.Deserialize<DownloadSummaryParams>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                     ?? new DownloadSummaryParams(".", "");
                 string filePath = await OnDownloadSummary(sumParams, ct).ConfigureAwait(false);
@@ -395,7 +400,8 @@ internal sealed class WebProgressServer : IDisposable
                     return "[]";
                 }
 
-                string body = await new StreamReader(ctx.Request.InputStream, ctx.Request.ContentEncoding).ReadToEndAsync(ct).ConfigureAwait(false);
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
                 CheckExistingParams checkParams = JsonSerializer.Deserialize<CheckExistingParams>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
                     ?? new CheckExistingParams(".", false, false);
                 object result = await OnCheckExisting(checkParams).ConfigureAwait(false);


### PR DESCRIPTION
Adds subject-type subfolders to invoice download paths so files are organized under per-subject directories (e.g. sprzedawca/nabywca/podmiot3/uprawniony), with optional NIP-based nesting. Improves UX and file organization but introduces a breaking change for existing downloads — previously saved files will not be detected until moved into the new subfolders or re-downloaded.

Significant changes:
- Routes and UI now carry subject type so downloads and existence checks place files into the appropriate subject folder.
- Download logic builds output path from base output dir → optional NIP → subject-type folder; preferences persist only the base output dir to avoid path duplication.
- Adds a subject-type-to-folder mapping and sanitised path joins for consistent cross-platform behaviour.
- API/IPC payload types extended to include subject type.
- Documentation updated (changelog and readme) with the new directory scheme and explicit breaking-change notice.

Rationale:
- Keeps downloaded invoices grouped by role and NIP, making file management and discovery easier.
- Prevents repeated path duplication in saved preferences.
- Documents the change so users can migrate existing files.

No issue reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Download directory layout now includes subject-type subfolders; previously downloaded invoices may not be detected until moved or re-downloaded.

* **Documentation**
  * Updated EN/PL README and changelog documenting the new directory scheme and 0.6.2 breaking change.

* **Bug Fixes / Improvements**
  * Automatic migration updates saved output-folder preferences to the new base layout.
  * GUI and backend include subject-type in check/download flows so files are stored correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->