### PR TITLE
feat: add XML cache, download progress, and DB health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.7] — unreleased
+
+### Added
+
+- **SQLite XML cache** — invoice XML fetched from KSeF is now stored in a new `invoice_xml_cache` table in the existing SQLite database. Subsequent requests for the same invoice (PDF preview, browser download, "Zapisz") reuse the cached XML without hitting the KSeF API. Cache persists across restarts and is keyed per profile.
+- **Browser download progress** — "Pobierz PDF / ZIP" now shows the progress bar and marks each invoice row in the table as it is processed, using the same SSE events (`invoice_start`, `pdf_done`) as the server-save flow. On completion the bar reaches 100% and the status line shows "Pobieranie gotowe."
+- **Startup database health check** — on every launch, `PRAGMA quick_check` is run against the SQLite database before the server starts. If corruption is detected, the app logs a `FATAL` error, opens a browser error page with the details and the database file path, and exits with code 1 instead of starting in a broken state.
+- **Selection cleared after download** — invoice row selections are automatically cleared after a successful "Zapisz zaznaczone / wszystkie" or "Pobierz PDF / ZIP" operation.
+
+### Fixed
+
+- Browser download ("Pobierz PDF / ZIP") no longer re-fetches XML from KSeF for invoices already downloaded or previewed in the same profile — hits the SQLite cache instead, avoiding rate-limit consumption on large batches.
+- Progress bar now auto-hides 1.2 s after a successful save or browser download instead of staying visible at 100%.
+
 ## [0.6.6] — 2026-05-04
 
 ### ⚠️ Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.7] — unreleased
+## [0.6.7] — 2026-05-05
 
 ### Added
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -313,6 +313,17 @@ public class GuiCommand : IWithConfigCommand
             _invoiceCache.CheckIntegrity();
             _invoiceCache.InitializeSchema();
         }
+        catch (DatabaseCorruptionException ex)
+        {
+            Log.LogError($"[startup] Database corrupted — cannot start.\n{ex.Message}");
+            Console.Error.WriteLine($"FATAL: {ex.Message}");
+            Console.Error.WriteLine("Delete or restore the database file and restart.");
+            WebProgressServer.ShowErrorPage(
+                "Baza danych uszkodzona — aplikacja nie może się uruchomić",
+                ex.Message,
+                _invoiceCache?.DbPath ?? InvoiceCache.DefaultDbPath);
+            return 1;
+        }
         catch (InvalidOperationException ex)
         {
             Log.LogError($"[startup] Database error — cannot start.\n{ex.Message}");

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -308,6 +308,18 @@ public class GuiCommand : IWithConfigCommand
         GuiPrefs savedPrefs = LoadPrefs();
         Log.ConfigureLogging(Verbose, Quiet, savedPrefs.JsonConsoleLog ?? false);
         _invoiceCache = new InvoiceCache();
+        try
+        {
+            _invoiceCache.CheckIntegrity();
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.LogError($"[startup] Database integrity check failed — cannot start.\n{ex.Message}");
+            Console.Error.WriteLine($"FATAL: {ex.Message}");
+            Console.Error.WriteLine("Delete or restore the database file and restart.");
+            WebProgressServer.ShowErrorPage("Błąd bazy danych — aplikacja nie może się uruchomić", ex.Message);
+            return 1;
+        }
         if (_setupRequired)
         {
             Log.LogInformation("No config file found. Opening setup wizard in GUI.");
@@ -2049,7 +2061,7 @@ public class GuiCommand : IWithConfigCommand
                 }
 
                 // Fetch XML — shared helper handles 429 rate-limit retry and 401 token-refresh.
-                string invoiceXml = await GetInvoiceXmlWithRetryAsync(inv.KsefNumber, ct).ConfigureAwait(false);
+                string invoiceXml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
 
                 // Write desired formats to workdir, then move to output
                 if (dlParams.ExportJson)
@@ -2156,6 +2168,20 @@ public class GuiCommand : IWithConfigCommand
         }
     }
 
+    private async Task<string> GetOrCacheInvoiceXmlAsync(string ksefNumber, CancellationToken ct)
+    {
+        string profileKey = GetProfileCacheKey();
+        string? cached = _invoiceCache.GetXml(profileKey, ksefNumber);
+        if (cached != null)
+        {
+            Log.LogInformation($"[xml-cache] hit for {ksefNumber}");
+            return cached;
+        }
+        string xml = await GetInvoiceXmlWithRetryAsync(ksefNumber, ct).ConfigureAwait(false);
+        _invoiceCache.SetXml(profileKey, ksefNumber, xml);
+        return xml;
+    }
+
     // Ownership of the returned Stream is transferred to the caller (WebProgressServer),
     // which disposes it via `await using`. CodeQL cannot track cross-method ownership.
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
@@ -2206,14 +2232,22 @@ public class GuiCommand : IWithConfigCommand
 
         if (toDownload.Count == 1)
         {
-            (int _, InvoiceSummary inv) = toDownload[0];
+            (int idx, InvoiceSummary inv) = toDownload[0];
+            if (_server != null)
+            {
+                await _server.SendEventAsync("invoice_start", new { current = idx, name = inv.KsefNumber, progress = 0, total = 1 }).ConfigureAwait(false);
+            }
             Log.LogInformation($"[browser-dl] Fetching XML for {inv.KsefNumber}");
-            string xml = await GetInvoiceXmlWithRetryAsync(inv.KsefNumber, ct).ConfigureAwait(false);
+            string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
             Log.LogInformation($"[browser-dl] Generating PDF for {inv.KsefNumber}");
             string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
             byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
             string safeName = SanitizeFileName(inv.KsefNumber) + ".pdf";
             Log.LogInformation($"[browser-dl] PDF ready: {safeName} ({pdf.Length} bytes)");
+            if (_server != null)
+            {
+                await _server.SendEventAsync("pdf_done", new { current = idx, progress = 1, total = 1 }).ConfigureAwait(false);
+            }
             return (new System.IO.MemoryStream(pdf), "application/pdf", safeName);
         }
         else
@@ -2227,11 +2261,15 @@ public class GuiCommand : IWithConfigCommand
             using (System.IO.Compression.ZipArchive zip = new(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
             {
                 int n = 0;
-                foreach ((int _, InvoiceSummary inv) in toDownload)
+                foreach ((int idx, InvoiceSummary inv) in toDownload)
                 {
                     n++;
+                    if (_server != null)
+                    {
+                        await _server.SendEventAsync("invoice_start", new { current = idx, name = inv.KsefNumber, progress = n - 1, total = toDownload.Count }).ConfigureAwait(false);
+                    }
                     Log.LogInformation($"[browser-dl] [{n}/{toDownload.Count}] Fetching {inv.KsefNumber}");
-                    string xml = await GetInvoiceXmlWithRetryAsync(inv.KsefNumber, ct).ConfigureAwait(false);
+                    string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
                     string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
                     byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
                     string entryName = SanitizeFileName(inv.KsefNumber) + ".pdf";
@@ -2241,6 +2279,10 @@ public class GuiCommand : IWithConfigCommand
                     await using (entryStream.ConfigureAwait(false))
                     {
                         await entryStream.WriteAsync(pdf, ct).ConfigureAwait(false);
+                    }
+                    if (_server != null)
+                    {
+                        await _server.SendEventAsync("pdf_done", new { current = idx, progress = n, total = toDownload.Count }).ConfigureAwait(false);
                     }
                 }
             }
@@ -2308,7 +2350,7 @@ public class GuiCommand : IWithConfigCommand
         }
 
         InvoiceSummary inv = _cachedInvoices[idx];
-        string xml = await GetInvoiceXmlWithRetryAsync(inv.KsefNumber, ct).ConfigureAwait(false);
+        string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
 
         XDocument doc = XDocument.Parse(xml);
         XNamespace fallbackNs = "http://crd.gov.pl/wzor/2025/06/25/13775/";

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -307,17 +307,20 @@ public class GuiCommand : IWithConfigCommand
         _setupRequired = !File.Exists(Path.GetFullPath(ConfigFile));
         GuiPrefs savedPrefs = LoadPrefs();
         Log.ConfigureLogging(Verbose, Quiet, savedPrefs.JsonConsoleLog ?? false);
-        _invoiceCache = new InvoiceCache();
         try
         {
+            _invoiceCache = new InvoiceCache();
             _invoiceCache.CheckIntegrity();
         }
         catch (InvalidOperationException ex)
         {
-            Log.LogError($"[startup] Database integrity check failed — cannot start.\n{ex.Message}");
+            Log.LogError($"[startup] Database error — cannot start.\n{ex.Message}");
             Console.Error.WriteLine($"FATAL: {ex.Message}");
             Console.Error.WriteLine("Delete or restore the database file and restart.");
-            WebProgressServer.ShowErrorPage("Błąd bazy danych — aplikacja nie może się uruchomić", ex.Message);
+            WebProgressServer.ShowErrorPage(
+                "Błąd bazy danych — aplikacja nie może się uruchomić",
+                ex.Message,
+                _invoiceCache?.DbPath ?? InvoiceCache.DefaultDbPath);
             return 1;
         }
         if (_setupRequired)
@@ -2171,14 +2174,28 @@ public class GuiCommand : IWithConfigCommand
     private async Task<string> GetOrCacheInvoiceXmlAsync(string ksefNumber, CancellationToken ct)
     {
         string profileKey = GetProfileCacheKey();
-        string? cached = _invoiceCache.GetXml(profileKey, ksefNumber);
-        if (cached != null)
+        try
         {
-            Log.LogInformation($"[xml-cache] hit for {ksefNumber}");
-            return cached;
+            string? cached = _invoiceCache.GetXml(profileKey, ksefNumber);
+            if (cached != null)
+            {
+                Log.LogInformation($"[xml-cache] hit for {ksefNumber}");
+                return cached;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[xml-cache] GetXml failed for {ksefNumber}, fetching from KSeF: {ex.Message}");
         }
         string xml = await GetInvoiceXmlWithRetryAsync(ksefNumber, ct).ConfigureAwait(false);
-        _invoiceCache.SetXml(profileKey, ksefNumber, xml);
+        try
+        {
+            _invoiceCache.SetXml(profileKey, ksefNumber, xml);
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning($"[xml-cache] SetXml failed for {ksefNumber}: {ex.Message}");
+        }
         return xml;
     }
 

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -311,6 +311,7 @@ public class GuiCommand : IWithConfigCommand
         {
             _invoiceCache = new InvoiceCache();
             _invoiceCache.CheckIntegrity();
+            _invoiceCache.InitializeSchema();
         }
         catch (InvalidOperationException ex)
         {
@@ -2134,12 +2135,16 @@ public class GuiCommand : IWithConfigCommand
         }
     }
 
-    private async Task<string> GetInvoiceXmlWithRetryAsync(string ksefNumber, CancellationToken ct)
+    private Task<string> GetInvoiceXmlWithRetryAsync(string ksefNumber, CancellationToken ct)
     {
-        // Snapshot profile identity before acquiring scope so ExpireStoredAccessToken targets the right profile.
         string requestProfile = ActiveProfile;
         ProfileConfig requestConfig = Config();
+        return GetInvoiceXmlWithRetryAsync(ksefNumber, requestProfile, requestConfig, ct);
+    }
 
+    private async Task<string> GetInvoiceXmlWithRetryAsync(
+        string ksefNumber, string requestProfile, ProfileConfig requestConfig, CancellationToken ct)
+    {
         // Own a fresh scope for this operation so a concurrent profile switch cannot dispose our client mid-retry.
         using IServiceScope requestScope = GetScope(requestConfig);
         IKSeFClient requestClient = requestScope.ServiceProvider.GetRequiredService<IKSeFClient>();
@@ -2173,14 +2178,18 @@ public class GuiCommand : IWithConfigCommand
 
     private async Task<string> GetOrCacheInvoiceXmlAsync(string ksefNumber, CancellationToken ct)
     {
-        string profileKey = GetProfileCacheKey();
+        // Snapshot once so cache read, KSeF fetch, and cache write all target the same profile.
+        string requestProfile = ActiveProfile;
+        ProfileConfig requestConfig = Config();
+        string profileKey = new TokenStore.Key(requestProfile, requestConfig).ToCacheKey();
+
         string? cached = _invoiceCache.TryGetXml(profileKey, ksefNumber);
         if (cached != null)
         {
             Log.LogInformation($"[xml-cache] hit for {ksefNumber}");
             return cached;
         }
-        string xml = await GetInvoiceXmlWithRetryAsync(ksefNumber, ct).ConfigureAwait(false);
+        string xml = await GetInvoiceXmlWithRetryAsync(ksefNumber, requestProfile, requestConfig, ct).ConfigureAwait(false);
         _invoiceCache.TrySetXml(profileKey, ksefNumber, xml);
         return xml;
     }

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -2174,28 +2174,14 @@ public class GuiCommand : IWithConfigCommand
     private async Task<string> GetOrCacheInvoiceXmlAsync(string ksefNumber, CancellationToken ct)
     {
         string profileKey = GetProfileCacheKey();
-        try
+        string? cached = _invoiceCache.TryGetXml(profileKey, ksefNumber);
+        if (cached != null)
         {
-            string? cached = _invoiceCache.GetXml(profileKey, ksefNumber);
-            if (cached != null)
-            {
-                Log.LogInformation($"[xml-cache] hit for {ksefNumber}");
-                return cached;
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.LogWarning($"[xml-cache] GetXml failed for {ksefNumber}, fetching from KSeF: {ex.Message}");
+            Log.LogInformation($"[xml-cache] hit for {ksefNumber}");
+            return cached;
         }
         string xml = await GetInvoiceXmlWithRetryAsync(ksefNumber, ct).ConfigureAwait(false);
-        try
-        {
-            _invoiceCache.SetXml(profileKey, ksefNumber, xml);
-        }
-        catch (Exception ex)
-        {
-            Log.LogWarning($"[xml-cache] SetXml failed for {ksefNumber}: {ex.Message}");
-        }
+        _invoiceCache.TrySetXml(profileKey, ksefNumber, xml);
         return xml;
     }
 

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -61,6 +61,14 @@ internal sealed class InvoiceCache
         {
             throw new InvalidOperationException($"Failed to initialize invoice database schema ({_dbPath}): {ex.Message}", ex);
         }
+        catch (IOException ex)
+        {
+            throw new InvalidOperationException($"Failed to initialize invoice database schema ({_dbPath}): {ex.Message}", ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new InvalidOperationException($"Failed to initialize invoice database schema ({_dbPath}): {ex.Message}", ex);
+        }
     }
 
     /// <summary>Creates the table if it does not already exist, and logs row counts per profile.</summary>

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -88,6 +88,18 @@ internal sealed class InvoiceCache
             }
         }
 
+        using SqliteCommand xmlCacheCmd = conn.CreateCommand();
+        xmlCacheCmd.CommandText = """
+            CREATE TABLE IF NOT EXISTS invoice_xml_cache (
+                profile_key  TEXT NOT NULL,
+                ksef_number  TEXT NOT NULL,
+                xml_content  TEXT NOT NULL,
+                fetched_at   TEXT NOT NULL,
+                PRIMARY KEY (profile_key, ksef_number)
+            )
+            """;
+        xmlCacheCmd.ExecuteNonQuery();
+
         // Log per-profile row summary for diagnostics
         using SqliteCommand statsCmd = conn.CreateCommand();
         statsCmd.CommandText = "SELECT profile_key, fetched_at, length(invoices_json) FROM invoice_cache ORDER BY fetched_at DESC";
@@ -461,6 +473,58 @@ internal sealed class InvoiceCache
         int pendingRetries = (int)(long)(pendingCmd.ExecuteScalar() ?? 0L);
 
         return new NotificationStatus(lastSentAt, pendingRetries, lastOk, lastFailed, lastRetryCount);
+    }
+
+    /// <summary>
+    /// Runs PRAGMA quick_check. Throws InvalidOperationException with details if corruption is detected.
+    /// </summary>
+    public void CheckIntegrity()
+    {
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA quick_check";
+        using SqliteDataReader reader = cmd.ExecuteReader();
+        List<string> findings = new();
+        while (reader.Read())
+        {
+            string row = reader.GetString(0);
+            if (!string.Equals(row, "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                findings.Add(row);
+            }
+        }
+        if (findings.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"SQLite database integrity check failed ({_dbPath}):\n" + string.Join("\n", findings));
+        }
+    }
+
+    public string? GetXml(string profileKey, string ksefNumber)
+    {
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT xml_content FROM invoice_xml_cache WHERE profile_key = @pk AND ksef_number = @kn";
+        cmd.Parameters.AddWithValue("@pk", profileKey);
+        cmd.Parameters.AddWithValue("@kn", ksefNumber);
+        object? result = cmd.ExecuteScalar();
+        return result as string;
+    }
+
+    public void SetXml(string profileKey, string ksefNumber, string xmlContent)
+    {
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            INSERT INTO invoice_xml_cache (profile_key, ksef_number, xml_content, fetched_at)
+            VALUES (@pk, @kn, @xml, @at)
+            ON CONFLICT(profile_key, ksef_number) DO UPDATE SET xml_content = excluded.xml_content, fetched_at = excluded.fetched_at
+            """;
+        cmd.Parameters.AddWithValue("@pk", profileKey);
+        cmd.Parameters.AddWithValue("@kn", ksefNumber);
+        cmd.Parameters.AddWithValue("@xml", xmlContent);
+        cmd.Parameters.AddWithValue("@at", DateTime.UtcNow.ToString("o"));
+        cmd.ExecuteNonQuery();
     }
 
     private SqliteConnection Open()

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -39,11 +39,6 @@ internal sealed class InvoiceCache
                 Directory.CreateDirectory(dir);
             }
             Log.LogInformation($"Invoice cache DB: {_dbPath} ({(isNew ? "new" : $"{new FileInfo(_dbPath).Length / 1024.0:F1} KB")})");
-            EnsureSchema();
-        }
-        catch (SqliteException ex)
-        {
-            throw new InvalidOperationException($"Failed to open invoice database ({_dbPath}): {ex.Message}", ex);
         }
         catch (IOException ex)
         {
@@ -52,6 +47,19 @@ internal sealed class InvoiceCache
         catch (UnauthorizedAccessException ex)
         {
             throw new InvalidOperationException($"Failed to open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>Creates tables and runs migrations. Must be called after CheckIntegrity() passes.</summary>
+    public void InitializeSchema()
+    {
+        try
+        {
+            EnsureSchema();
+        }
+        catch (SqliteException ex)
+        {
+            throw new InvalidOperationException($"Failed to initialize invoice database schema ({_dbPath}): {ex.Message}", ex);
         }
     }
 

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -569,6 +569,11 @@ internal sealed class InvoiceCache
             Log.LogWarning($"[xml-cache] GetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
             return null;
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            Log.LogWarning($"[xml-cache] GetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
+            return null;
+        }
     }
 
     public void TrySetXml(string profileKey, string ksefNumber, string xmlContent)
@@ -582,6 +587,10 @@ internal sealed class InvoiceCache
             Log.LogWarning($"[xml-cache] SetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
         }
         catch (IOException ex)
+        {
+            Log.LogWarning($"[xml-cache] SetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
+        }
+        catch (UnauthorizedAccessException ex)
         {
             Log.LogWarning($"[xml-cache] SetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
         }

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -17,24 +17,34 @@ internal sealed class InvoiceCache
     private static readonly string DefaultPath =
         Path.Combine(IGlobalCommand.CacheDir, "db", "invoice-cache.db");
 
+    public static string DefaultDbPath => DefaultPath;
+
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true,
     };
 
     private readonly string _dbPath;
+    public string DbPath => _dbPath;
 
     public InvoiceCache(string? dbPath = null)
     {
         _dbPath = dbPath ?? DefaultPath;
-        bool isNew = !File.Exists(_dbPath);
-        string? dir = Path.GetDirectoryName(_dbPath);
-        if (!string.IsNullOrEmpty(dir))
+        try
         {
-            Directory.CreateDirectory(dir);
+            bool isNew = !File.Exists(_dbPath);
+            string? dir = Path.GetDirectoryName(_dbPath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            Log.LogInformation($"Invoice cache DB: {_dbPath} ({(isNew ? "new" : $"{new FileInfo(_dbPath).Length / 1024.0:F1} KB")})");
+            EnsureSchema();
         }
-        Log.LogInformation($"Invoice cache DB: {_dbPath} ({(isNew ? "new" : $"{new FileInfo(_dbPath).Length / 1024.0:F1} KB")})");
-        EnsureSchema();
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            throw new InvalidOperationException($"Failed to open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
     }
 
     /// <summary>Creates the table if it does not already exist, and logs row counts per profile.</summary>
@@ -480,23 +490,34 @@ internal sealed class InvoiceCache
     /// </summary>
     public void CheckIntegrity()
     {
-        using SqliteConnection conn = Open();
-        using SqliteCommand cmd = conn.CreateCommand();
-        cmd.CommandText = "PRAGMA quick_check";
-        using SqliteDataReader reader = cmd.ExecuteReader();
-        List<string> findings = new();
-        while (reader.Read())
+        try
         {
-            string row = reader.GetString(0);
-            if (!string.Equals(row, "ok", StringComparison.OrdinalIgnoreCase))
+            using SqliteConnection conn = Open();
+            using SqliteCommand cmd = conn.CreateCommand();
+            cmd.CommandText = "PRAGMA quick_check";
+            using SqliteDataReader reader = cmd.ExecuteReader();
+            List<string> findings = new();
+            while (reader.Read())
             {
-                findings.Add(row);
+                string row = reader.GetString(0);
+                if (!string.Equals(row, "ok", StringComparison.OrdinalIgnoreCase))
+                {
+                    findings.Add(row);
+                }
+            }
+            if (findings.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"SQLite database integrity check failed ({_dbPath}):\n" + string.Join("\n", findings));
             }
         }
-        if (findings.Count > 0)
+        catch (InvalidOperationException)
         {
-            throw new InvalidOperationException(
-                $"SQLite database integrity check failed ({_dbPath}):\n" + string.Join("\n", findings));
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
         }
     }
 

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -41,7 +41,15 @@ internal sealed class InvoiceCache
             Log.LogInformation($"Invoice cache DB: {_dbPath} ({(isNew ? "new" : $"{new FileInfo(_dbPath).Length / 1024.0:F1} KB")})");
             EnsureSchema();
         }
-        catch (Exception ex) when (ex is not InvalidOperationException)
+        catch (SqliteException ex)
+        {
+            throw new InvalidOperationException($"Failed to open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
+        catch (IOException ex)
+        {
+            throw new InvalidOperationException($"Failed to open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
+        catch (UnauthorizedAccessException ex)
         {
             throw new InvalidOperationException($"Failed to open invoice database ({_dbPath}): {ex.Message}", ex);
         }
@@ -515,9 +523,51 @@ internal sealed class InvoiceCache
         {
             throw;
         }
-        catch (Exception ex)
+        catch (SqliteException ex)
         {
             throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
+        catch (IOException ex)
+        {
+            throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
+        }
+    }
+
+    public string? TryGetXml(string profileKey, string ksefNumber)
+    {
+        try
+        {
+            return GetXml(profileKey, ksefNumber);
+        }
+        catch (SqliteException ex)
+        {
+            Log.LogWarning($"[xml-cache] GetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
+            return null;
+        }
+        catch (IOException ex)
+        {
+            Log.LogWarning($"[xml-cache] GetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
+            return null;
+        }
+    }
+
+    public void TrySetXml(string profileKey, string ksefNumber, string xmlContent)
+    {
+        try
+        {
+            SetXml(profileKey, ksefNumber, xmlContent);
+        }
+        catch (SqliteException ex)
+        {
+            Log.LogWarning($"[xml-cache] SetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
+        }
+        catch (IOException ex)
+        {
+            Log.LogWarning($"[xml-cache] SetXml failed ({ex.GetType().Name}) for ksef_number ending ...{ksefNumber[^Math.Min(4, ksefNumber.Length)..]}");
         }
     }
 

--- a/src/KSeFCli/InvoiceCache.cs
+++ b/src/KSeFCli/InvoiceCache.cs
@@ -12,6 +12,12 @@ namespace KSeFCli;
 /// re-fetch is to discover newly arrived invoices.
 /// DB location: ~/.cache/ksefcli/db/invoice-cache.db
 /// </summary>
+internal sealed class DatabaseCorruptionException : Exception
+{
+    public DatabaseCorruptionException(string dbPath, string details)
+        : base($"SQLite database integrity check failed ({dbPath}):\n{details}") { }
+}
+
 internal sealed class InvoiceCache
 {
     private static readonly string DefaultPath =
@@ -510,46 +516,28 @@ internal sealed class InvoiceCache
     }
 
     /// <summary>
-    /// Runs PRAGMA quick_check. Throws InvalidOperationException with details if corruption is detected.
+    /// Runs PRAGMA quick_check. Throws <see cref="DatabaseCorruptionException"/> if corruption is
+    /// detected; propagates <see cref="SqliteException"/>, <see cref="IOException"/>, and
+    /// <see cref="UnauthorizedAccessException"/> as-is for access/lock problems.
     /// </summary>
     public void CheckIntegrity()
     {
-        try
+        using SqliteConnection conn = Open();
+        using SqliteCommand cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA quick_check";
+        using SqliteDataReader reader = cmd.ExecuteReader();
+        List<string> findings = new();
+        while (reader.Read())
         {
-            using SqliteConnection conn = Open();
-            using SqliteCommand cmd = conn.CreateCommand();
-            cmd.CommandText = "PRAGMA quick_check";
-            using SqliteDataReader reader = cmd.ExecuteReader();
-            List<string> findings = new();
-            while (reader.Read())
+            string row = reader.GetString(0);
+            if (!string.Equals(row, "ok", StringComparison.OrdinalIgnoreCase))
             {
-                string row = reader.GetString(0);
-                if (!string.Equals(row, "ok", StringComparison.OrdinalIgnoreCase))
-                {
-                    findings.Add(row);
-                }
-            }
-            if (findings.Count > 0)
-            {
-                throw new InvalidOperationException(
-                    $"SQLite database integrity check failed ({_dbPath}):\n" + string.Join("\n", findings));
+                findings.Add(row);
             }
         }
-        catch (InvalidOperationException)
+        if (findings.Count > 0)
         {
-            throw;
-        }
-        catch (SqliteException ex)
-        {
-            throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
-        }
-        catch (IOException ex)
-        {
-            throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            throw new InvalidOperationException($"Cannot open invoice database ({_dbPath}): {ex.Message}", ex);
+            throw new DatabaseCorruptionException(_dbPath, string.Join("\n", findings));
         }
     }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -185,6 +185,57 @@ internal sealed class WebProgressServer : IDisposable
         }
     }
 
+    public static void ShowErrorPage(string title, string detail)
+    {
+        string safeTitle = System.Net.WebUtility.HtmlEncode(title);
+        string safeDetail = System.Net.WebUtility.HtmlEncode(detail);
+        string html = $$"""
+            <!DOCTYPE html>
+            <html lang="pl">
+            <head>
+              <meta charset="utf-8">
+              <title>{{safeTitle}}</title>
+              <style>
+                body { font-family: sans-serif; max-width: 720px; margin: 4rem auto; padding: 0 1.5rem; background: #fafafa; color: #212121; }
+                h1 { color: #b71c1c; }
+                pre { background: #fff3e0; border: 1px solid #ffcc80; padding: 1rem; border-radius: 4px; white-space: pre-wrap; word-break: break-word; font-size: .85rem; }
+                .hint { border-left: 4px solid #e53935; padding: .75rem 1rem; background: #fff; margin-top: 1.5rem; }
+              </style>
+            </head>
+            <body>
+              <h1>⚠ {{safeTitle}}</h1>
+              <pre>{{safeDetail}}</pre>
+              <div class="hint">
+                <strong>Co zrobić:</strong> Usuń lub przywróć plik bazy danych i uruchom aplikację ponownie.<br>
+                Plik bazy: <code>~/.cache/ksefcli/db/invoice-cache.db</code>
+              </div>
+            </body>
+            </html>
+            """;
+        string path = Path.Combine(Path.GetTempPath(), "ksefcli-error.html");
+        try
+        {
+            File.WriteAllText(path, html, Encoding.UTF8);
+            string fileUrl = "file:///" + path.Replace('\\', '/').TrimStart('/');
+            if (OperatingSystem.IsLinux())
+            {
+                System.Diagnostics.Process.Start("xdg-open", fileUrl);
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                System.Diagnostics.Process.Start("open", path);
+            }
+            else if (OperatingSystem.IsWindows())
+            {
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", $"/c start \"\" \"{path}\"") { CreateNoWindow = true });
+            }
+        }
+        catch
+        {
+            // Browser open failed — user still sees the FATAL message on stderr.
+        }
+    }
+
     public void Dispose()
     {
         _cts?.Cancel();
@@ -2415,9 +2466,10 @@ function connectSSE() {
       case 'all_done':
         setStatus('Gotowe! Pobrano ' + (d.count || dlTotal) + ' faktur.', 'done');
         bar.style.width = '100%'; bar.textContent = '100%';
+        clearSelection();
         btnSearch.disabled = false; btnDownload.disabled = false;
-        btnDownloadSel.disabled = selectedInvoices.size === 0; btnBrowserDownload.disabled = selectedInvoices.size === 0;
         checkExisting();
+        setTimeout(() => progressWrap.classList.remove('visible'), 1200);
         break;
       case 'error': {
         const row = document.getElementById('row-' + d.current);
@@ -2813,6 +2865,7 @@ async function doDownload(selOnly) {
 
 async function doBrowserDownload() {
   const indices = selectedInvoices.size > 0 ? [...selectedInvoices] : null;
+  const count = indices ? indices.length : total;
   const month = $('fromDate').value || new Date().toISOString().slice(0, 7);
   const body = {
     indices,
@@ -2820,6 +2873,10 @@ async function doBrowserDownload() {
     month
   };
   setBusyState(true);
+  completed = 0; dlTotal = count;
+  progressWrap.classList.add('visible');
+  bar.style.width = '0%'; bar.textContent = '0%';
+  setStatus('Generowanie PDF... 0 / ' + count, 'info');
   try {
     const res = await fetch('/download-browser', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
     if (!res.ok) { let msg = 'HTTP ' + res.status; try { const e = await res.json(); msg = e.error || msg; } catch { msg = await res.text().then(t => t.slice(0,120)).catch(() => msg); } throw new Error(msg); }
@@ -2833,8 +2890,13 @@ async function doBrowserDownload() {
     document.body.appendChild(a);
     a.click();
     setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 0);
+    clearSelection();
+    bar.style.width = '100%'; bar.textContent = '100%';
+    setStatus('Pobieranie gotowe.', 'done');
+    setTimeout(() => progressWrap.classList.remove('visible'), 1200);
   } catch (err) {
     setStatus('Błąd pobierania: ' + err.message, 'error');
+    progressWrap.classList.remove('visible');
   } finally {
     setBusyState(false);
   }

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -2471,7 +2471,7 @@ function connectSSE() {
         clearSelection();
         btnSearch.disabled = false; btnDownload.disabled = false;
         checkExisting();
-        setTimeout(() => progressWrap.classList.remove('visible'), 1200);
+        clearTimeout(progressHideTimeoutId); progressHideTimeoutId = setTimeout(hideProgress, 1200);
         break;
       case 'error': {
         const row = document.getElementById('row-' + d.current);
@@ -2517,6 +2517,8 @@ function connectSSE() {
 }
 
 let dlTotal = 0;
+let progressHideTimeoutId = null;
+function hideProgress() { progressHideTimeoutId = null; progressWrap.classList.remove('visible'); }
 function markDone(idx) {
   const row = document.getElementById('row-' + idx);
   const icon = document.getElementById('icon-' + idx);
@@ -2896,7 +2898,7 @@ async function doBrowserDownload() {
     clearSelection();
     bar.style.width = '100%'; bar.textContent = '100%';
     setStatus('Pobieranie gotowe.', 'done');
-    setTimeout(() => progressWrap.classList.remove('visible'), 1200);
+    clearTimeout(progressHideTimeoutId); progressHideTimeoutId = setTimeout(hideProgress, 1200);
   } catch (err) {
     setStatus('Błąd pobierania: ' + err.message, 'error');
     progressWrap.classList.remove('visible');

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -185,10 +185,11 @@ internal sealed class WebProgressServer : IDisposable
         }
     }
 
-    public static void ShowErrorPage(string title, string detail)
+    public static void ShowErrorPage(string title, string detail, string? dbPath = null)
     {
         string safeTitle = System.Net.WebUtility.HtmlEncode(title);
         string safeDetail = System.Net.WebUtility.HtmlEncode(detail);
+        string safeDbPath = System.Net.WebUtility.HtmlEncode(dbPath ?? "~/.cache/ksefcli/db/invoice-cache.db");
         string html = $$"""
             <!DOCTYPE html>
             <html lang="pl">
@@ -207,12 +208,12 @@ internal sealed class WebProgressServer : IDisposable
               <pre>{{safeDetail}}</pre>
               <div class="hint">
                 <strong>Co zrobić:</strong> Usuń lub przywróć plik bazy danych i uruchom aplikację ponownie.<br>
-                Plik bazy: <code>~/.cache/ksefcli/db/invoice-cache.db</code>
+                Plik bazy: <code>{{safeDbPath}}</code>
               </div>
             </body>
             </html>
             """;
-        string path = Path.Combine(Path.GetTempPath(), "ksefcli-error.html");
+        string path = Path.Join(Path.GetTempPath(), "ksefcli-error.html");
         try
         {
             File.WriteAllText(path, html, Encoding.UTF8);
@@ -230,10 +231,11 @@ internal sealed class WebProgressServer : IDisposable
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", $"/c start \"\" \"{path}\"") { CreateNoWindow = true });
             }
         }
-        catch
-        {
-            // Browser open failed — user still sees the FATAL message on stderr.
-        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+        catch (System.ComponentModel.Win32Exception) { }
+        catch (InvalidOperationException) { }
+        catch (PlatformNotSupportedException) { }
     }
 
     public void Dispose()
@@ -2877,6 +2879,7 @@ async function doBrowserDownload() {
   progressWrap.classList.add('visible');
   bar.style.width = '0%'; bar.textContent = '0%';
   setStatus('Generowanie PDF... 0 / ' + count, 'info');
+  connectSSE();
   try {
     const res = await fetch('/download-browser', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
     if (!res.ok) { let msg = 'HTTP ' + res.status; try { const e = await res.json(); msg = e.error || msg; } catch { msg = await res.text().then(t => t.slice(0,120)).catch(() => msg); } throw new Error(msg); }

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -231,11 +231,11 @@ internal sealed class WebProgressServer : IDisposable
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", $"/c start \"\" \"{path}\"") { CreateNoWindow = true });
             }
         }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
-        catch (System.ComponentModel.Win32Exception) { }
-        catch (InvalidOperationException) { }
-        catch (PlatformNotSupportedException) { }
+        catch (IOException ex) { Log.LogDebug($"[error-page] {ex.Message}"); }
+        catch (UnauthorizedAccessException ex) { Log.LogDebug($"[error-page] {ex.Message}"); }
+        catch (System.ComponentModel.Win32Exception ex) { Log.LogDebug($"[error-page] {ex.Message}"); }
+        catch (InvalidOperationException ex) { Log.LogDebug($"[error-page] {ex.Message}"); }
+        catch (PlatformNotSupportedException ex) { Log.LogDebug($"[error-page] {ex.Message}"); }
     }
 
     public void Dispose()


### PR DESCRIPTION
- Invoice XML now cached in SQLite — repeated PDF/preview/download ops skip the KSeF API entirely
- Browser download shows live progress bar and marks rows as they complete, same as server-save flow
- DB integrity check runs on startup; shows error page and exits if corruption is found
- Row selections cleared automatically after successful save or browser download
- Progress bar auto-hides 1.2s after completion instead of staying at 100%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local SQLite-backed invoice XML cache to avoid refetching and speed up preview/download.
  * Browser download progress wired to SSE with a “Pobieranie gotowe” completion message.

* **Bug Fixes**
  * Downloads and details now reuse cached XML when available.
  * Progress bar auto-hides shortly after success (~1.2s) instead of lingering.
  * Invoice row selection clears after successful save or browser download.
* **Chores**
  * Startup runs a DB integrity check and shows a friendly error page on corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->