### PR TITLE
feat: add custom filenames to browser download

### DIFF
--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -2341,15 +2341,16 @@ public class GuiCommand : IWithConfigCommand
     internal static string SanitizeFileName(string name)
     {
         // Path.GetInvalidFileNameChars() is OS-specific; ':' is missing on Linux but invalid on Windows.
-        // Include it explicitly for cross-platform filename compatibility.
-        HashSet<char> invalid = new HashSet<char>(Path.GetInvalidFileNameChars()) { ':', '*', '?', '"', '<', '>', '|' };
+        // '/' and '\' are path separators on one or both platforms — must be excluded from ZIP entry names too.
+        HashSet<char> invalid = new HashSet<char>(Path.GetInvalidFileNameChars()) { ':', '*', '?', '"', '<', '>', '|', '/', '\\' };
         string sanitized = string.Join("", name.Select(c => invalid.Contains(c) || c == ' ' ? '_' : c));
         if (sanitized.Length > 60)
         {
             sanitized = sanitized[..60];
         }
 
-        return sanitized.Trim();
+        sanitized = sanitized.Trim();
+        return string.IsNullOrEmpty(sanitized) ? "faktura" : sanitized;
     }
 
     private async Task<string> AuthAsync(CancellationToken ct)

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -2265,7 +2265,7 @@ public class GuiCommand : IWithConfigCommand
             Log.LogInformation($"[browser-dl] Generating PDF for {inv.KsefNumber}");
             string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
             byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
-            string safeName = SanitizeFileName(inv.KsefNumber) + ".pdf";
+            string safeName = BuildFileName(inv, dlParams.CustomFilenames) + ".pdf";
             Log.LogInformation($"[browser-dl] PDF ready: {safeName} ({pdf.Length} bytes)");
             if (_server != null)
             {
@@ -2295,7 +2295,7 @@ public class GuiCommand : IWithConfigCommand
                     string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
                     string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
                     byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
-                    string entryName = SanitizeFileName(inv.KsefNumber) + ".pdf";
+                    string entryName = BuildFileName(inv, dlParams.CustomFilenames) + ".pdf";
                     Log.LogInformation($"[browser-dl] [{n}/{toDownload.Count}] Added {entryName} ({pdf.Length} bytes)");
                     System.IO.Compression.ZipArchiveEntry entry = zip.CreateEntry(entryName, System.IO.Compression.CompressionLevel.Fastest);
                     System.IO.Stream entryStream = entry.Open();

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -2284,6 +2284,7 @@ public class GuiCommand : IWithConfigCommand
             using (System.IO.Compression.ZipArchive zip = new(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
             {
                 int n = 0;
+                HashSet<string> usedNames = new(StringComparer.OrdinalIgnoreCase);
                 foreach ((int idx, InvoiceSummary inv) in toDownload)
                 {
                     n++;
@@ -2295,7 +2296,12 @@ public class GuiCommand : IWithConfigCommand
                     string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
                     string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
                     byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
-                    string entryName = BuildFileName(inv, dlParams.CustomFilenames) + ".pdf";
+                    string baseName = BuildFileName(inv, dlParams.CustomFilenames);
+                    string entryName = baseName + ".pdf";
+                    for (int dup = 2; !usedNames.Add(entryName); dup++)
+                    {
+                        entryName = baseName + $"_{dup}.pdf";
+                    }
                     Log.LogInformation($"[browser-dl] [{n}/{toDownload.Count}] Added {entryName} ({pdf.Length} bytes)");
                     System.IO.Compression.ZipArchiveEntry entry = zip.CreateEntry(entryName, System.IO.Compression.CompressionLevel.Fastest);
                     System.IO.Stream entryStream = entry.Open();

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -2319,7 +2319,7 @@ public class GuiCommand : IWithConfigCommand
     {
         if (!customScheme)
         {
-            return UseInvoiceNumber ? inv.InvoiceNumber : inv.KsefNumber;
+            return UseInvoiceNumber ? SanitizeFileName(inv.InvoiceNumber) : inv.KsefNumber;
         }
 
         string date = inv.IssueDate.ToString("yyyy-MM-dd");

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -12,7 +12,7 @@ internal record SearchParams(string SubjectType, string From, string? To, string
 internal record DownloadParams(string OutputDir, int[]? SelectedIndices, bool CustomFilenames, bool ExportXml = true, bool ExportJson = false, bool ExportPdf = true, bool SeparateByNip = false, string? PdfColorScheme = null, string? SubjectType = null);
 internal record CheckExistingParams(string OutputDir, bool CustomFilenames, bool SeparateByNip, string? SubjectType = null);
 internal record DownloadSummaryParams(string OutputDir, string Month, bool SeparateByNip = false);
-internal record BrowserDownloadParams(int[]? Indices, string? PdfColorScheme = null, string? Month = null);
+internal record BrowserDownloadParams(int[]? Indices, string? PdfColorScheme = null, string? Month = null, bool CustomFilenames = false);
 
 internal sealed class WebProgressServer : IDisposable
 {
@@ -2874,7 +2874,8 @@ async function doBrowserDownload() {
   const body = {
     indices,
     pdfColorScheme: $('pdfColorScheme').value,
-    month
+    month,
+    customFilenames: $('customFilenames').checked
   };
   setBusyState(true);
   completed = 0; dlTotal = count;


### PR DESCRIPTION
- Browser download now reads the custom filenames toggle and passes it through to file naming
- ZIP entries and single PDF downloads both use the custom name builder instead of raw KSeF number


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI checkbox to enable custom filenames for browser PDF downloads (single PDF and ZIP batches); when enabled, filenames can use the invoice number.
  * ZIP creation now avoids duplicate entry names by appending a suffix to duplicates.
* **Bug Fixes**
  * Improved filename sanitization to exclude path separators for safe, cross-platform ZIP and file names.
  * Custom-filename mode now sanitizes invoice numbers before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->