### PR TITLE
Adds browser CSV download and updates KSeF client to v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [0.6.9] — unreleased
 
+### Added
+
+- **"Pobierz CSV" browser download button** (orange) — downloads the monthly CSV summary directly to the browser without saving to the server; "Podsumowanie CSV" renamed to "Zapisz CSV" (purple), behaviour unchanged.
+- **NBP rate loading indicator** — shows "⏳ Pobieranie kursów NBP…" while rates are being fetched instead of a static "waiting" message; `refreshExchangeRates()` is now called before `buildCurrencyFilter()` so `fxRatesFetchInProgress` is set before the first render.
+
+### Fixed
+
+- **Profile switch clears invoice list** — switching profiles now fully clears the invoice view (previously cached invoices for the new profile were immediately loaded and displayed); token status is refreshed synchronously for the new profile.
+- **"Zapisz CSV" / "Pobierz CSV" button state** — buttons are enabled only when the invoice list is non-empty, regardless of ongoing download operations; they are no longer blocked by `setBusyState` during invoice save/download flows.
+
 ### Changed
 
-- **KSeF client updated to v2.4.0** (był rc6.1.1 z 2025-12-18) — dodaje obsługę formatu Problem Details dla błędów 400/429/410, wsparcie HTTP 410 Gone dla wygasłych operacji eksportu oraz parametr `onlyMetadata` dla eksportu faktur.
+- **KSeF client updated to v2.4.0** (was rc6.1.1 from 2025-12-18) — adds Problem Details error handling for 400/429/410 responses, HTTP 410 Gone support for expired export operations, and `onlyMetadata` parameter for invoice exports.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.9] — unreleased
+## [0.6.9] — 2026-05-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.9] — unreleased
+
+### Changed
+
+- **KSeF client updated to v2.4.0** (był rc6.1.1 z 2025-12-18) — dodaje obsługę formatu Problem Details dla błędów 400/429/410, wsparcie HTTP 410 Gone dla wygasłych operacji eksportu oraz parametr `onlyMetadata` dla eksportu faktur.
+
+---
+
 ## [0.6.8] — 2026-05-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ All notable changes to this project will be documented in this file.
 
 - **"Pobierz CSV" browser download button** (orange) — downloads the monthly CSV summary directly to the browser without saving to the server; "Podsumowanie CSV" renamed to "Zapisz CSV" (purple), behaviour unchanged.
 - **NBP rate loading indicator** — shows "⏳ Pobieranie kursów NBP…" while rates are being fetched instead of a static "waiting" message; `refreshExchangeRates()` is now called before `buildCurrencyFilter()` so `fxRatesFetchInProgress` is set before the first render.
+- **PDF — additional FA(3) annotation fields** — four fields previously missing from the PDF are now rendered when present in the invoice XML: `P_19C` (other legal basis for VAT exemption), `P_22` (intra-EU delivery of new means of transport), `P_23` (simplified procedure in triangular transactions), `TP` (related parties). All are shown conditionally — no label is printed when the field is absent.
+- **PDF — margin procedure annotations** — `P_PMarzy` family now parsed and displayed: "procedura marży dla biur podróży" (`P_PMarzy_2`), "procedura marży - towary używane" (`P_PMarzy_3_1`), "procedura marży - dzieła sztuki" (`P_PMarzy_3_2`), "procedura marży - przedmioty kolekcjonerskie i antyki" (`P_PMarzy_3_3`).
 
 ### Fixed
 
+- **PDF — annotation field mapping corrected** — three fields were mapped to wrong regulatory labels due to FA(3) schema numbering: `P_16` is "Metoda kasowa" (not reverse charge), `P_18` is "odwrotne obciążenie" (not margin scheme), `P_18A` is "mechanizm podzielonej płatności" (not new means of transport). Field `P_PMarzy` (margin scheme) was not parsed at all.
+- **PDF — VAT exemption labels corrected** — `P_19` is now shown as a marker ("Zwolnienie z VAT"), `P_19A` label changed to "Przepis ustawy", `P_19B` label changed to "Przepis dyrektywy 2006/112/WE".
 - **Profile switch clears invoice list** — switching profiles now fully clears the invoice view (previously cached invoices for the new profile were immediately loaded and displayed); token status is refreshed synchronously for the new profile.
 - **"Zapisz CSV" / "Pobierz CSV" button state** — buttons are enabled only when the invoice list is non-empty, regardless of ongoing download operations; they are no longer blocked by `setBusyState` during invoice save/download flows.
 

--- a/src/KSeFCli.Tests/TestData/invoice-reverse-charge.xml
+++ b/src/KSeFCli.Tests/TestData/invoice-reverse-charge.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Scenario: Reverse charge (P_16=1) + self-billing (P_17=1) annotations -->
+<!-- Scenario: Reverse charge (P_18=1) + self-billing (P_17=1) + cash method (P_16=1) annotations -->
 <Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
   <Naglowek>
     <KodFormularza kodSystemowy="FA (2)" wersjaSchemy="1-0E">FA</KodFormularza>
@@ -36,6 +36,7 @@
     <RodzajFaktury>VAT</RodzajFaktury>
     <P_16>1</P_16>
     <P_17>1</P_17>
+    <P_18>1</P_18>
     <FaWiersz>
       <NrWierszaFa>1</NrWierszaFa>
       <P_7>Złom stalowy (odwrotne obciążenie)</P_7>

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -2137,7 +2137,7 @@ public class GuiCommand : IWithConfigCommand
                     IVerificationLinkService? pdfLinkSvc = _scope?.ServiceProvider.GetService<IVerificationLinkService>();
                     string? ksefVerificationUrl = TryBuildVerificationUrl(pdfLinkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
 
-                    byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme, inv.KsefNumber, ksefVerificationUrl).ConfigureAwait(false);
+                    byte[] pdfContent = await XML2PDFCommand.XML2PDF(invoiceXml, Quiet, ct, dlParams.PdfColorScheme, inv.KsefNumber, ksefVerificationUrl, inv.InvoiceHash).ConfigureAwait(false);
                     string tmpPdf = Path.Combine(workDir, $"{fileName}.pdf");
                     await File.WriteAllBytesAsync(tmpPdf, pdfContent, ct).ConfigureAwait(false);
                     string finalPdf = Path.Combine(outputDir, $"{fileName}.pdf");
@@ -2297,7 +2297,7 @@ public class GuiCommand : IWithConfigCommand
             string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
             Log.LogInformation($"[browser-dl] Generating PDF for {inv.KsefNumber}");
             string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
-            byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
+            byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl, inv.InvoiceHash).ConfigureAwait(false);
             string safeName = BuildFileName(inv, dlParams.CustomFilenames) + ".pdf";
             Log.LogInformation($"[browser-dl] PDF ready: {safeName} ({pdf.Length} bytes)");
             if (_server != null)
@@ -2328,7 +2328,7 @@ public class GuiCommand : IWithConfigCommand
                     Log.LogInformation($"[browser-dl] [{n}/{toDownload.Count}] Fetching {inv.KsefNumber}");
                     string xml = await GetOrCacheInvoiceXmlAsync(inv.KsefNumber, ct).ConfigureAwait(false);
                     string? verificationUrl = TryBuildVerificationUrl(linkSvc, inv.Seller?.Nip, inv.IssueDate, inv.InvoiceHash);
-                    byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl).ConfigureAwait(false);
+                    byte[] pdf = await XML2PDFCommand.XML2PDF(xml, Quiet, ct, colorScheme, inv.KsefNumber, verificationUrl, inv.InvoiceHash).ConfigureAwait(false);
                     string baseName = BuildFileName(inv, dlParams.CustomFilenames);
                     string entryName = baseName + ".pdf";
                     for (int dup = 2; !usedNames.Add(entryName); dup++)

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -432,6 +432,7 @@ public class GuiCommand : IWithConfigCommand
         server.OnDownload = DownloadAsync;
         server.OnBrowserDownload = BrowserDownloadAsync;
         server.OnDownloadSummary = GenerateSummaryAsync;
+        server.OnBrowserDownloadSummary = BrowserDownloadSummaryAsync;
         server.OnAuth = AuthAsync;
         server.OnInvoiceDetails = InvoiceDetailsAsync;
         server.OnQuit = () =>
@@ -1931,17 +1932,52 @@ public class GuiCommand : IWithConfigCommand
 
     private Task<string> GenerateSummaryAsync(DownloadSummaryParams sumParams, CancellationToken ct)
     {
-        // Snapshot mutable state immediately to avoid races with profile/cache switches
         List<InvoiceSummary>? cached = _cachedInvoices?.ToList();
         string profile = ActiveProfile;
         string? nip = sumParams.SeparateByNip ? Config().Nip : null;
 
+        (string monthKey, List<InvoiceSummary> filtered) = ParseAndFilterSummary(cached, sumParams.Month);
+
+        string outputDir = string.IsNullOrWhiteSpace(sumParams.OutputDir) ? OutputDir : sumParams.OutputDir;
+        if (!string.IsNullOrEmpty(nip))
+        {
+            outputDir = Path.Join(outputDir, nip);
+        }
+        Directory.CreateDirectory(outputDir);
+        string filePath = Path.Join(outputDir, $"summary-{monthKey}.csv");
+
+        Log.LogInformation($"[summary] Generating monthly summary for profile '{profile}', month={monthKey}, invoices in cache={cached!.Count}, matching={filtered.Count}, output={filePath}");
+
+        byte[] bytes = BuildSummaryCsvBytes(filtered, monthKey);
+        File.WriteAllBytes(filePath, bytes);
+
+        Log.LogInformation($"[summary] Saved {filtered.Count} invoice(s) for {monthKey} to {filePath} ({bytes.Length} bytes)");
+        return Task.FromResult(filePath);
+    }
+
+    private Task<(System.IO.Stream Data, string ContentType, string FileName)> BrowserDownloadSummaryAsync(
+        DownloadSummaryParams sumParams, CancellationToken ct)
+    {
+        List<InvoiceSummary>? cached = _cachedInvoices?.ToList();
+        string profile = ActiveProfile;
+
+        (string monthKey, List<InvoiceSummary> filtered) = ParseAndFilterSummary(cached, sumParams.Month);
+
+        Log.LogInformation($"[summary-dl] Browser download for profile '{profile}', month={monthKey}, matching={filtered.Count}");
+
+        byte[] bytes = BuildSummaryCsvBytes(filtered, monthKey);
+        string fileName = $"summary-{monthKey}.csv";
+        return Task.FromResult<(System.IO.Stream, string, string)>((new System.IO.MemoryStream(bytes), "text/csv; charset=utf-8", fileName));
+    }
+
+    private static (string MonthKey, List<InvoiceSummary> Filtered) ParseAndFilterSummary(
+        List<InvoiceSummary>? cached, string month)
+    {
         if (cached == null || cached.Count == 0)
         {
             throw new InvalidOperationException("Brak faktur. Wykonaj najpierw wyszukiwanie.");
         }
 
-        string month = sumParams.Month; // "YYYY-MM"
         if (!DateOnly.TryParseExact(month, "yyyy-MM", out DateOnly parsedMonth))
         {
             throw new InvalidOperationException($"Nieprawidłowy format miesiąca: '{month}'. Oczekiwany format: RRRR-MM.");
@@ -1953,16 +1989,11 @@ public class GuiCommand : IWithConfigCommand
             .OrderBy(i => i.IssueDate)
             .ToList();
 
-        string outputDir = string.IsNullOrWhiteSpace(sumParams.OutputDir) ? OutputDir : sumParams.OutputDir;
-        if (!string.IsNullOrEmpty(nip))
-        {
-            outputDir = Path.Join(outputDir, nip);
-        }
-        Directory.CreateDirectory(outputDir);
-        string filePath = Path.Join(outputDir, $"summary-{monthKey}.csv");
+        return (monthKey, filtered);
+    }
 
-        Log.LogInformation($"[summary] Generating monthly summary for profile '{profile}', month={monthKey}, invoices in cache={cached.Count}, matching={filtered.Count}, output={filePath}");
-
+    private static byte[] BuildSummaryCsvBytes(List<InvoiceSummary> filtered, string monthKey)
+    {
         StringBuilder sb = new();
         sb.AppendLine($"Podsumowanie faktur za: {monthKey}");
         sb.AppendLine($"Liczba faktur: {filtered.Count}");
@@ -1989,14 +2020,9 @@ public class GuiCommand : IWithConfigCommand
             sb.AppendLine($"Razem {grp.Key}:;{total.ToString("F2", System.Globalization.CultureInfo.InvariantCulture)}");
         }
 
-        // UTF-8 with BOM for Excel compatibility
         byte[] bom = [0xEF, 0xBB, 0xBF];
         byte[] content = Encoding.UTF8.GetBytes(sb.ToString());
-        byte[] bytes = [.. bom, .. content];
-        File.WriteAllBytes(filePath, bytes);
-
-        Log.LogInformation($"[summary] Saved {filtered.Count} invoice(s) for {monthKey} to {filePath} ({bytes.Length} bytes)");
-        return Task.FromResult(filePath);
+        return [.. bom, .. content];
 
         static string Csv(string? value)
         {
@@ -2005,7 +2031,6 @@ public class GuiCommand : IWithConfigCommand
                 return "";
             }
 
-            // Neutralize formula injection: Excel/Calc treat cells starting with =,+,-,@ as formulas
             if (value[0] is '=' or '+' or '-' or '@')
             {
                 value = "'" + value;

--- a/src/KSeFCli/GuiCommand.cs
+++ b/src/KSeFCli/GuiCommand.cs
@@ -1955,6 +1955,12 @@ public class GuiCommand : IWithConfigCommand
         return Task.FromResult(filePath);
     }
 
+    // Ownership of the returned Stream is transferred to the caller (WebProgressServer),
+    // which disposes it via `await using`. CodeQL cannot track cross-method ownership.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000",
+        Justification = "Stream ownership is transferred to the caller which disposes it.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "cs/local-not-disposed",
+        Justification = "Stream ownership is transferred to the caller which disposes it.")]
     private Task<(System.IO.Stream Data, string ContentType, string FileName)> BrowserDownloadSummaryAsync(
         DownloadSummaryParams sumParams, CancellationToken ct)
     {
@@ -2031,7 +2037,9 @@ public class GuiCommand : IWithConfigCommand
                 return "";
             }
 
-            if (value[0] is '=' or '+' or '-' or '@')
+            int firstNonWs = 0;
+            while (firstNonWs < value.Length && char.IsWhiteSpace(value[firstNonWs])) { firstNonWs++; }
+            if (firstNonWs < value.Length && value[firstNonWs] is '=' or '+' or '-' or '@')
             {
                 value = "'" + value;
             }

--- a/src/KSeFCli/IWithConfigCommand.cs
+++ b/src/KSeFCli/IWithConfigCommand.cs
@@ -94,17 +94,13 @@ public abstract class IWithConfigCommand : IGlobalCommand
         return new TokenStore.Key(config.ActiveProfile, profile);
     }
 
-    private static string StatusInfoToString(StatusInfo statusInfo)
+    private static string StatusInfoToString(OperationStatusInfo statusInfo)
     {
         StringBuilder sb = new StringBuilder();
         sb.Append($"Code: {statusInfo.Code}, Description: {statusInfo.Description}");
         if (statusInfo.Details != null && statusInfo.Details.Any())
         {
             sb.Append($", Details: [{string.Join(", ", statusInfo.Details)}]");
-        }
-        if (statusInfo.Extensions != null && statusInfo.Extensions.Any())
-        {
-            sb.Append($", Extensions: {{{string.Join(", ", statusInfo.Extensions.Select(kv => $"{kv.Key}: {kv.Value}"))}}}");
         }
         return sb.ToString();
     }

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -1851,8 +1851,7 @@ public static class KSeFInvoicePdf
         if (string.IsNullOrEmpty(normalizedVerificationUrl)) { normalizedVerificationUrl = null; }
 
         string? normalizedHash = ksefInvoiceHash?.Trim();
-        if (string.IsNullOrEmpty(normalizedHash)) { normalizedHash = null; }
-        else if (normalizedHash.Length > MaxKsefHashLength) { normalizedHash = normalizedHash[..MaxKsefHashLength]; }
+        if (string.IsNullOrEmpty(normalizedHash) || normalizedHash.Length > MaxKsefHashLength) { normalizedHash = null; }
 
         InvoiceData data = KSeFInvoiceSanitizer.Sanitize(xmlContent, KSeFInvoiceParser.Parse(xmlContent));
         return KSeFInvoicePdfGenerator.Generate(

--- a/src/KSeFCli/KSeFInvoicePdf.cs
+++ b/src/KSeFCli/KSeFInvoicePdf.cs
@@ -73,13 +73,18 @@ internal record InvoiceData(
     string? WZ,
     List<string> NrUmowy,
     string? NrFaZaliczkowej,
-    bool OdwrotneObciazenie,
+    bool MetodaKasowa,
     bool Samofakturowanie,
-    string? ProceduraMarzy,
-    bool NoweŚrodkiTransportu,
+    bool OdwrotneObciazenie,
+    bool MechanizmPodzielonejPlatnosci,
+    string? ProceduraMarzySzczegoly,
     string? PodstawaZwolnienia,
     string? PodstawaZwolnieniaA,
     string? PodstawaZwolnieniaB,
+    string? PodstawaZwolnieniaC,
+    bool DostawaWewnatrzwspolnotowa,
+    bool ProceduraUproszczona,
+    bool PodmiotyPowiazane,
     List<string> NrZamowienia,
     string? NrPartiiDostawy,
     string? Incoterms,
@@ -89,6 +94,8 @@ internal record InvoiceData(
     string? SystemInfo,
     // Not in the XML — injected from API response metadata after parsing
     string? KsefReferenceNumber,
+    // SHA-256 hash of the invoice document (base64), returned by the KSeF API as InvoiceHash.
+    string? KsefInvoiceHash,
     // Pre-computed KSeF verification URL: https://qr.ksef.mf.gov.pl/invoice/{nip}/{dd-MM-yyyy}/{hash}
     // Built by IVerificationLinkService in the download/search pipeline; null when not available.
     string? KsefVerificationUrl
@@ -312,13 +319,23 @@ internal static class KSeFInvoiceParser
             WZ: Val(fa, "WZ"),
             NrUmowy: umowy,
             NrFaZaliczkowej: nrFaZal,
-            OdwrotneObciazenie: Val(fa, "P_16") == "1",
+            MetodaKasowa: Val(fa, "P_16") == "1",
             Samofakturowanie: Val(fa, "P_17") == "1",
-            ProceduraMarzy: Val(fa, "P_18"),
-            NoweŚrodkiTransportu: Val(fa, "P_18A") == "1",
-            PodstawaZwolnienia: Val(fa, "P_19"),
+            OdwrotneObciazenie: Val(fa, "P_18") == "1",
+            MechanizmPodzielonejPlatnosci: Val(fa, "P_18A") == "1",
+            ProceduraMarzySzczegoly:
+                El(fa, "P_PMarzy_2") != null ? "procedura marży dla biur podróży" :
+                El(fa, "P_PMarzy_3_1") != null ? "procedura marży - towary używane" :
+                El(fa, "P_PMarzy_3_2") != null ? "procedura marży - dzieła sztuki" :
+                El(fa, "P_PMarzy_3_3") != null ? "procedura marży - przedmioty kolekcjonerskie i antyki" :
+                El(fa, "P_PMarzy") != null ? "procedura marży" : null,
+            PodstawaZwolnienia: Val(fa, "P_19") == "1" ? "tak" : null,
             PodstawaZwolnieniaA: Val(fa, "P_19A"),
             PodstawaZwolnieniaB: Val(fa, "P_19B"),
+            PodstawaZwolnieniaC: Val(fa, "P_19C"),
+            DostawaWewnatrzwspolnotowa: Val(fa, "P_22") == "1",
+            ProceduraUproszczona: Val(fa, "P_23") == "1",
+            PodmiotyPowiazane: Val(fa, "TP") == "1",
             NrZamowienia: zamowienia,
             NrPartiiDostawy: nrPartiiDostawy,
             Incoterms: incoterms,
@@ -327,6 +344,7 @@ internal static class KSeFInvoiceParser
             Bdo: rejestry is null ? null : Val(rejestry, "BDO"),
             SystemInfo: Val(naglowek, "SystemInfo"),
             KsefReferenceNumber: null,
+            KsefInvoiceHash: null,
             KsefVerificationUrl: null
         );
     }
@@ -604,10 +622,11 @@ internal static class KSeFInvoiceSanitizer
         WZ = Text(d.WZ),
         NrUmowy = d.NrUmowy.Select(u => Text(u) ?? "").ToList(),
         NrFaZaliczkowej = Text(d.NrFaZaliczkowej),
-        ProceduraMarzy = Text(d.ProceduraMarzy),
-        PodstawaZwolnienia = Text(d.PodstawaZwolnienia),
+        ProceduraMarzySzczegoly = Text(d.ProceduraMarzySzczegoly),
+        PodstawaZwolnienia = d.PodstawaZwolnienia,
         PodstawaZwolnieniaA = Text(d.PodstawaZwolnieniaA),
         PodstawaZwolnieniaB = Text(d.PodstawaZwolnieniaB),
+        PodstawaZwolnieniaC = Text(d.PodstawaZwolnieniaC),
         NrZamowienia = d.NrZamowienia.Select(z => Text(z) ?? "").ToList(),
         NrPartiiDostawy = Text(d.NrPartiiDostawy),
         Incoterms = Text(d.Incoterms),
@@ -1025,6 +1044,14 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                             t.Span(d.KsefReferenceNumber).FontSize(8).Bold().FontColor(RedAccent);
                         });
                     }
+                    if (!string.IsNullOrEmpty(d.KsefInvoiceHash))
+                    {
+                        right.Item().PaddingTop(1).Text(t =>
+                        {
+                            t.Span("Skrót dokumentu: ").FontSize(6.5f).FontColor(Gray);
+                            t.Span(d.KsefInvoiceHash).FontSize(6.5f).FontColor(Gray);
+                        });
+                    }
                 });
             });
 
@@ -1113,10 +1140,14 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                     }
                     // Special procedure flags
                     List<string> flags = new List<string>();
-                    if (d.OdwrotneObciazenie) { flags.Add("Odwrotne obciążenie (P_16)"); }
-                    if (d.Samofakturowanie) { flags.Add("Samofakturowanie (P_17)"); }
-                    if (!string.IsNullOrEmpty(d.ProceduraMarzy)) { flags.Add("Procedura marży: " + d.ProceduraMarzy); }
-                    if (d.NoweŚrodkiTransportu) { flags.Add("Nowe środki transportu (P_18A)"); }
+                    if (d.MetodaKasowa) { flags.Add("Metoda kasowa"); }
+                    if (d.Samofakturowanie) { flags.Add("samofakturowanie"); }
+                    if (d.OdwrotneObciazenie) { flags.Add("odwrotne obciążenie"); }
+                    if (d.MechanizmPodzielonejPlatnosci) { flags.Add("mechanizm podzielonej płatności"); }
+                    if (!string.IsNullOrEmpty(d.ProceduraMarzySzczegoly)) { flags.Add(d.ProceduraMarzySzczegoly); }
+                    if (d.DostawaWewnatrzwspolnotowa) { flags.Add("WDT nowych środków transportu"); }
+                    if (d.ProceduraUproszczona) { flags.Add("procedura uproszczona — transakcja trójstronna (art. 136)"); }
+                    if (d.PodmiotyPowiazane) { flags.Add("podmioty powiązane"); }
                     foreach (string flag in flags)
                     {
                         det.Item().PaddingTop(2).Text(t =>
@@ -1124,20 +1155,19 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                             t.Span(flag).FontSize(7.5f).Bold().FontColor(RedAccent);
                         });
                     }
-                    // VAT exemption basis
+                    // VAT exemption basis (P_19 is a marker; P_19A/B/C carry the legal text)
                     if (!string.IsNullOrEmpty(d.PodstawaZwolnienia))
                     {
                         det.Item().PaddingTop(2).Text(t =>
                         {
-                            t.Span("Podstawa zwolnienia (P_19): ").FontSize(7.5f).FontColor(Gray);
-                            t.Span(d.PodstawaZwolnienia).FontSize(7.5f);
+                            t.Span("Zwolnienie z VAT (P_19)").FontSize(7.5f).Bold().FontColor(RedAccent);
                         });
                     }
                     if (!string.IsNullOrEmpty(d.PodstawaZwolnieniaA))
                     {
                         det.Item().PaddingTop(1).Text(t =>
                         {
-                            t.Span("Przepis (P_19A): ").FontSize(7.5f).FontColor(Gray);
+                            t.Span("Przepis ustawy (P_19A): ").FontSize(7.5f).FontColor(Gray);
                             t.Span(d.PodstawaZwolnieniaA).FontSize(7.5f);
                         });
                     }
@@ -1145,8 +1175,16 @@ internal sealed class KSeFInvoicePdfGenerator(PdfColorScheme scheme)
                     {
                         det.Item().PaddingTop(1).Text(t =>
                         {
-                            t.Span("Opis zwolnienia (P_19B): ").FontSize(7.5f).FontColor(Gray);
+                            t.Span("Przepis dyrektywy 2006/112/WE (P_19B): ").FontSize(7.5f).FontColor(Gray);
                             t.Span(d.PodstawaZwolnieniaB).FontSize(7.5f);
+                        });
+                    }
+                    if (!string.IsNullOrEmpty(d.PodstawaZwolnieniaC))
+                    {
+                        det.Item().PaddingTop(1).Text(t =>
+                        {
+                            t.Span("Inna podstawa zwolnienia (P_19C): ").FontSize(7.5f).FontColor(Gray);
+                            t.Span(d.PodstawaZwolnieniaC).FontSize(7.5f);
                         });
                     }
                     // Transaction conditions
@@ -1795,31 +1833,30 @@ public static class KSeFInvoicePdf
     // KSeF reference numbers follow the pattern NIP-YYYYMMDD-HASH-SEQ; cap at 256 (same as TZnakowy in FA3.xsd).
     private const int MaxKsefReferenceNumberLength = 256;
 
+    // SHA-256 in base64 is always 44 chars; cap generously to guard against malformed values.
+    private const int MaxKsefHashLength = 64;
+
     public static byte[] FromXml(
         string xmlContent,
         string? colorScheme = null,
         string? ksefReferenceNumber = null,
-        string? ksefVerificationUrl = null)
+        string? ksefVerificationUrl = null,
+        string? ksefInvoiceHash = null)
     {
         string? normalizedKsefRef = ksefReferenceNumber?.Trim();
-        if (string.IsNullOrEmpty(normalizedKsefRef))
-        {
-            normalizedKsefRef = null;
-        }
-        else if (normalizedKsefRef.Length > MaxKsefReferenceNumberLength)
-        {
-            normalizedKsefRef = normalizedKsefRef[..MaxKsefReferenceNumberLength];
-        }
+        if (string.IsNullOrEmpty(normalizedKsefRef)) { normalizedKsefRef = null; }
+        else if (normalizedKsefRef.Length > MaxKsefReferenceNumberLength) { normalizedKsefRef = normalizedKsefRef[..MaxKsefReferenceNumberLength]; }
 
         string? normalizedVerificationUrl = ksefVerificationUrl?.Trim();
-        if (string.IsNullOrEmpty(normalizedVerificationUrl))
-        {
-            normalizedVerificationUrl = null;
-        }
+        if (string.IsNullOrEmpty(normalizedVerificationUrl)) { normalizedVerificationUrl = null; }
+
+        string? normalizedHash = ksefInvoiceHash?.Trim();
+        if (string.IsNullOrEmpty(normalizedHash)) { normalizedHash = null; }
+        else if (normalizedHash.Length > MaxKsefHashLength) { normalizedHash = normalizedHash[..MaxKsefHashLength]; }
 
         InvoiceData data = KSeFInvoiceSanitizer.Sanitize(xmlContent, KSeFInvoiceParser.Parse(xmlContent));
         return KSeFInvoicePdfGenerator.Generate(
-            data with { KsefReferenceNumber = normalizedKsefRef, KsefVerificationUrl = normalizedVerificationUrl },
+            data with { KsefReferenceNumber = normalizedKsefRef, KsefInvoiceHash = normalizedHash, KsefVerificationUrl = normalizedVerificationUrl },
             PdfColorScheme.FromName(colorScheme));
     }
 }

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -539,6 +539,11 @@ internal sealed class WebProgressServer : IDisposable
                     await dataStream.CopyToAsync(ctx.Response.OutputStream, ct).ConfigureAwait(false);
                 }
             }
+            catch (InvalidOperationException ex)
+            {
+                Log.LogWarning($"[summary-dl] Validation error: {ex.Message}");
+                WriteErrorResponse(ctx, 400, ex.Message);
+            }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 Log.LogError($"[summary-dl] {ex.GetType().Name}: {ex.Message}");
@@ -2967,7 +2972,7 @@ async function doSummary() {
   } catch (err) {
     setStatus('Błąd: ' + err.message, 'error');
   } finally {
-    btnSummary.disabled = false;
+    updateSummaryButtons();
   }
 }
 
@@ -2993,7 +2998,7 @@ async function doBrowserSummary() {
   } catch (err) {
     setStatus('Błąd: ' + err.message, 'error');
   } finally {
-    btnSummaryBrowser.disabled = false;
+    updateSummaryButtons();
   }
 }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -549,6 +549,11 @@ internal sealed class WebProgressServer : IDisposable
                 Log.LogError($"[summary-dl] {ex.GetType().Name}: {ex.Message}");
                 WriteErrorResponse(ctx, 500, "Internal server error");
             }
+            finally
+            {
+                try { ctx.Response.Close(); }
+                catch (ObjectDisposedException) { }
+            }
         }
         else if (path == "/invoice-details" && method == "GET")
         {
@@ -2999,7 +3004,7 @@ async function doBrowserSummary() {
   } catch (err) {
     setStatus('Błąd: ' + err.message, 'error');
   } finally {
-    updateSummaryButtons();
+    summaryInFlight = false; updateSummaryButtons();
   }
 }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -528,17 +528,21 @@ internal sealed class WebProgressServer : IDisposable
                 (System.IO.Stream dataStream, string contentType, string fileName) = await OnBrowserDownloadSummary(sumParams, ct).ConfigureAwait(false);
                 await using (dataStream.ConfigureAwait(false))
                 {
-                    ctx.Response.ContentType = contentType;
                     ctx.Response.StatusCode = 200;
-                    ctx.Response.Headers["Content-Disposition"] = $"attachment; filename=\"{fileName}\"";
-                    ctx.Response.ContentLength64 = dataStream.Length;
+                    ctx.Response.ContentType = contentType;
+                    string safeBase = Path.GetFileName(fileName);
+                    if (string.IsNullOrWhiteSpace(safeBase)) { safeBase = "summary.csv"; }
+                    safeBase = System.Text.RegularExpressions.Regex.Replace(safeBase, @"[\x00-\x1F\x7F""\\]", "_");
+                    string encoded = Uri.EscapeDataString(safeBase);
+                    ctx.Response.Headers["Content-Disposition"] = $"attachment; filename=\"{safeBase}\"; filename*=UTF-8''{encoded}";
+                    if (dataStream.CanSeek) { ctx.Response.ContentLength64 = dataStream.Length; }
                     await dataStream.CopyToAsync(ctx.Response.OutputStream, ct).ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 Log.LogError($"[summary-dl] {ex.GetType().Name}: {ex.Message}");
-                WriteErrorResponse(ctx, 500, ex.Message);
+                WriteErrorResponse(ctx, 500, "Internal server error");
             }
         }
         else if (path == "/invoice-details" && method == "GET")

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -517,6 +517,7 @@ internal sealed class WebProgressServer : IDisposable
             if (OnBrowserDownloadSummary == null)
             {
                 WriteErrorResponse(ctx, 501, "Browser summary download not configured");
+                ctx.Response.Close();
                 return;
             }
             try
@@ -539,12 +540,16 @@ internal sealed class WebProgressServer : IDisposable
                     await dataStream.CopyToAsync(ctx.Response.OutputStream, ct).ConfigureAwait(false);
                 }
             }
+            catch (OperationCanceledException)
+            {
+                Log.LogInformation("[summary-dl] Cancelled by client.");
+            }
             catch (InvalidOperationException ex)
             {
                 Log.LogWarning($"[summary-dl] Validation error: {ex.Message}");
                 WriteErrorResponse(ctx, 400, ex.Message);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex)
             {
                 Log.LogError($"[summary-dl] {ex.GetType().Name}: {ex.Message}");
                 WriteErrorResponse(ctx, 500, "Internal server error");
@@ -552,7 +557,7 @@ internal sealed class WebProgressServer : IDisposable
             finally
             {
                 try { ctx.Response.Close(); }
-                catch (ObjectDisposedException) { }
+                catch (ObjectDisposedException ex) { Log.LogDebug($"[summary-dl] Response already disposed: {ex.Message}"); }
             }
         }
         else if (path == "/invoice-details" && method == "GET")

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -40,6 +40,9 @@ internal sealed class WebProgressServer : IDisposable
     /// <summary>Called when the user requests a monthly summary CSV. Returns the output file path.</summary>
     public Func<DownloadSummaryParams, CancellationToken, Task<string>>? OnDownloadSummary { get; set; }
 
+    /// <summary>Called when the user requests a monthly summary CSV for browser download. Returns (stream, contentType, fileName).</summary>
+    public Func<DownloadSummaryParams, CancellationToken, Task<(System.IO.Stream Data, string ContentType, string FileName)>>? OnBrowserDownloadSummary { get; set; }
+
     /// <summary>Called when the user requests ad-hoc browser download. Returns (stream, contentType, fileName). Caller disposes the stream.</summary>
     public Func<BrowserDownloadParams, CancellationToken, Task<(System.IO.Stream Data, string ContentType, string FileName)>>? OnBrowserDownload { get; set; }
 
@@ -508,6 +511,35 @@ internal sealed class WebProgressServer : IDisposable
                 string filePath = await OnDownloadSummary(sumParams, ct).ConfigureAwait(false);
                 return JsonSerializer.Serialize(new { ok = true, filePath });
             }).ConfigureAwait(false);
+        }
+        else if (path == "/download-summary-browser" && method == "POST")
+        {
+            if (OnBrowserDownloadSummary == null)
+            {
+                WriteErrorResponse(ctx, 501, "Browser summary download not configured");
+                return;
+            }
+            try
+            {
+                using StreamReader bodyReader = new(ctx.Request.InputStream, ctx.Request.ContentEncoding);
+                string body = await bodyReader.ReadToEndAsync(ct).ConfigureAwait(false);
+                DownloadSummaryParams sumParams = JsonSerializer.Deserialize<DownloadSummaryParams>(body, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                    ?? new DownloadSummaryParams(".", "");
+                (System.IO.Stream dataStream, string contentType, string fileName) = await OnBrowserDownloadSummary(sumParams, ct).ConfigureAwait(false);
+                await using (dataStream.ConfigureAwait(false))
+                {
+                    ctx.Response.ContentType = contentType;
+                    ctx.Response.StatusCode = 200;
+                    ctx.Response.Headers["Content-Disposition"] = $"attachment; filename=\"{fileName}\"";
+                    ctx.Response.ContentLength64 = dataStream.Length;
+                    await dataStream.CopyToAsync(ctx.Response.OutputStream, ct).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.LogError($"[summary-dl] {ex.GetType().Name}: {ex.Message}");
+                WriteErrorResponse(ctx, 500, ex.Message);
+            }
         }
         else if (path == "/invoice-details" && method == "GET")
         {
@@ -1397,7 +1429,8 @@ body.dark .pref-label{color:#aaa}
   <button class="btn-success" id="btnDownloadSel" onclick="doDownload(true)">Zapisz zaznaczone</button>
   <button class="btn-success" id="btnDownload" onclick="doDownload(false)" style="background:#1976d2">Zapisz wszystkie</button>
   <button class="btn-success" id="btnBrowserDownload" onclick="doBrowserDownload()" style="background:#e65100">Pobierz PDF</button>
-  <button class="btn-success" id="btnSummary" onclick="doSummary()" style="background:#7b1fa2">Podsumowanie CSV</button>
+  <button class="btn-success" id="btnSummary" onclick="doSummary()" style="background:#7b1fa2" disabled>Zapisz CSV</button>
+  <button class="btn-success" id="btnSummaryBrowser" onclick="doBrowserSummary()" style="background:#e65100" disabled>Pobierz CSV</button>
   <span class="count" id="countLabel"></span>
 </div>
 <div class="modal-overlay" id="folderModal">
@@ -1455,7 +1488,7 @@ const bar = $('bar'), progressWrap = $('progressWrap'),
       tableWrap = $('tableWrap'), downloadBar = $('downloadBar'), filterBar = $('filterBar'),
       selToolbar = $('selToolbar'), selCount = $('selCount'),
       btnSearch = $('btnSearch'), btnDownload = $('btnDownload'), btnDownloadSel = $('btnDownloadSel'), btnBrowserDownload = $('btnBrowserDownload'),
-      btnSummary = $('btnSummary'), countLabel = $('countLabel');
+      btnSummary = $('btnSummary'), btnSummaryBrowser = $('btnSummaryBrowser'), countLabel = $('countLabel');
 let invoices = [], total = 0, completed = 0, sortCol = null, sortAsc = true, es = null;
 let profileSwitchGen = 0; // incremented on every profile switch; stale async results discard themselves
 let activeCurrencies = new Set();
@@ -1523,8 +1556,8 @@ async function loadCachedInvoices() {
       };
       knownInvoiceKsefNumbers = new Set(invoices.map(i => i.ksefNumber));
     }
+    refreshExchangeRates(); // sets fxRatesFetchInProgress before buildCurrencyFilter renders
     buildCurrencyFilter();
-    refreshExchangeRates(); // async — re-renders chart with PLN equivalents when rates arrive
     displayAll = false;
     currentPage = 0;
     renderTable();
@@ -1729,9 +1762,10 @@ async function onProfileChange() {
   countLabel.textContent = '';
   lastSearchParams = null;
   knownInvoiceKsefNumbers = null;
-  setStatus('Profil zmieniony na "' + chosen + '".', 'idle');
-  fetchTokenStatus();
-  loadCachedInvoices();
+  buildCurrencyFilter();
+  renderTable();
+  setStatus('Profil zmieniony na "' + chosen + '". Kliknij Szukaj aby wyszukać faktury.', 'idle');
+  await fetchTokenStatus();
 }
 
 function togglePrefs() { openPrefs(); }
@@ -2245,7 +2279,7 @@ function buildCurrencyFilter() {
     let summaryHtml = '';
     const allRatesMissing = hasNonPln && missingRate && !convertedAny;
     if (hasNonPln && fxRatesFetchInProgress) {
-      summaryHtml = '<div class="hbar-summary hbar-summary-wait">Oczekiwanie na kursy NBP…</div>';
+      summaryHtml = '<div class="hbar-summary hbar-summary-wait">⏳ Pobieranie kursów NBP…</div>';
     } else if (hasNonPln && fxRatesFetchFailed && Object.keys(fxRates).length === 0) {
       summaryHtml = '<div class="hbar-summary hbar-summary-warn">Nie udało się pobrać kursów NBP</div>';
     } else if (hasNonPln && Object.keys(fxRates).length === 0) {
@@ -2281,6 +2315,7 @@ function updateFilteredCount() {
 }
 
 function renderTable() {
+  updateSummaryButtons();
   if (!invoices.length) { tableWrap.innerHTML = '<div class="empty">Brak faktur.</div>'; return; }
   const cols = [
     {key:'ksefNumber', label:'Numer KSeF'},
@@ -2610,6 +2645,12 @@ function setBusyState(busy) {
   btnBrowserDownload.disabled = busy || selectedInvoices.size === 0;
 }
 
+function updateSummaryButtons() {
+  const hasInvoices = total > 0;
+  btnSummary.disabled = !hasInvoices;
+  btnSummaryBrowser.disabled = !hasInvoices;
+}
+
 async function doSearch() {
   searchRunning = true;
   setBusyState(true);
@@ -2647,8 +2688,8 @@ async function doSearch() {
     } else {
       setStatus('Znaleziono ' + total + ' faktur.', total > 0 ? 'info' : 'idle');
     }
+    refreshExchangeRates(); // sets fxRatesFetchInProgress before buildCurrencyFilter renders
     buildCurrencyFilter();
-    refreshExchangeRates(); // async — re-renders chart with PLN equivalents when rates arrive
     displayAll = false;
     currentPage = 0;
     renderTable();
@@ -2721,8 +2762,8 @@ async function silentRefresh() {
     } else {
       setStatus('Auto-od\u015Bwie\u017Canie: ' + total + ' faktur.', 'idle');
     }
+    refreshExchangeRates(); // sets fxRatesFetchInProgress before buildCurrencyFilter renders
     buildCurrencyFilter();
-    refreshExchangeRates(); // async — keeps PLN conversions fresh during background refreshes
     renderTable();
     checkExisting();
     await fetchTokenStatus();
@@ -2923,6 +2964,32 @@ async function doSummary() {
     setStatus('Błąd: ' + err.message, 'error');
   } finally {
     btnSummary.disabled = false;
+  }
+}
+
+async function doBrowserSummary() {
+  const month = $('fromDate').value;
+  if (!month) { setStatus('Wybierz miesiąc w polu "Od".', 'error'); return; }
+  btnSummaryBrowser.disabled = true;
+  setStatus('Generowanie CSV...', 'info');
+  try {
+    const body = { outputDir: '.', month, separateByNip: false };
+    const res = await fetch('/download-summary-browser', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
+    if (!res.ok) { let msg = 'HTTP ' + res.status; try { const e = await res.json(); msg = e.error || msg; } catch {} throw new Error(msg); }
+    const disposition = res.headers.get('Content-Disposition') || '';
+    const nameMatch = disposition.match(/filename="([^"]+)"/);
+    const fileName = nameMatch ? nameMatch[1] : 'summary.csv';
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = fileName;
+    document.body.appendChild(a); a.click();
+    setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 0);
+    setStatus('Pobieranie CSV gotowe.', 'done');
+  } catch (err) {
+    setStatus('Błąd: ' + err.message, 'error');
+  } finally {
+    btnSummaryBrowser.disabled = false;
   }
 }
 

--- a/src/KSeFCli/WebProgressServer.cs
+++ b/src/KSeFCli/WebProgressServer.cs
@@ -535,7 +535,7 @@ internal sealed class WebProgressServer : IDisposable
                     safeBase = System.Text.RegularExpressions.Regex.Replace(safeBase, @"[\x00-\x1F\x7F""\\]", "_");
                     string encoded = Uri.EscapeDataString(safeBase);
                     ctx.Response.Headers["Content-Disposition"] = $"attachment; filename=\"{safeBase}\"; filename*=UTF-8''{encoded}";
-                    if (dataStream.CanSeek) { ctx.Response.ContentLength64 = dataStream.Length; }
+                    if (dataStream.CanSeek) { dataStream.Seek(0, System.IO.SeekOrigin.Begin); ctx.Response.ContentLength64 = dataStream.Length; }
                     await dataStream.CopyToAsync(ctx.Response.OutputStream, ct).ConfigureAwait(false);
                 }
             }
@@ -2654,10 +2654,11 @@ function setBusyState(busy) {
   btnBrowserDownload.disabled = busy || selectedInvoices.size === 0;
 }
 
+let summaryInFlight = false;
 function updateSummaryButtons() {
   const hasInvoices = total > 0;
-  btnSummary.disabled = !hasInvoices;
-  btnSummaryBrowser.disabled = !hasInvoices;
+  btnSummary.disabled = !hasInvoices || summaryInFlight;
+  btnSummaryBrowser.disabled = !hasInvoices || summaryInFlight;
 }
 
 async function doSearch() {
@@ -2961,7 +2962,7 @@ async function doBrowserDownload() {
 async function doSummary() {
   const month = $('fromDate').value;
   if (!month) { setStatus('Wybierz miesiąc w polu "Od".', 'error'); return; }
-  btnSummary.disabled = true;
+  summaryInFlight = true; updateSummaryButtons();
   setStatus('Generowanie podsumowania...', 'info');
   try {
     const body = { outputDir: $('outputDir').value || '.', month, separateByNip: $('separateByNip').checked };
@@ -2972,14 +2973,14 @@ async function doSummary() {
   } catch (err) {
     setStatus('Błąd: ' + err.message, 'error');
   } finally {
-    updateSummaryButtons();
+    summaryInFlight = false; updateSummaryButtons();
   }
 }
 
 async function doBrowserSummary() {
   const month = $('fromDate').value;
   if (!month) { setStatus('Wybierz miesiąc w polu "Od".', 'error'); return; }
-  btnSummaryBrowser.disabled = true;
+  summaryInFlight = true; updateSummaryButtons();
   setStatus('Generowanie CSV...', 'info');
   try {
     const body = { outputDir: '.', month, separateByNip: false };

--- a/src/KSeFCli/XML2PDFCommand.cs
+++ b/src/KSeFCli/XML2PDFCommand.cs
@@ -56,14 +56,15 @@ public class XML2PDFCommand : IGlobalCommand
 
     public static Task<byte[]> XML2PDF(
         string xmlContent, bool quiet, CancellationToken cancellationToken,
-        string? colorScheme = null, string? ksefReferenceNumber = null, string? ksefVerificationUrl = null)
+        string? colorScheme = null, string? ksefReferenceNumber = null, string? ksefVerificationUrl = null,
+        string? ksefInvoiceHash = null)
     {
         if (!quiet)
         {
             Log.LogInformation("Generating PDF (native renderer)...");
         }
 
-        return Task.FromResult(KSeFInvoicePdf.FromXml(xmlContent, colorScheme, ksefReferenceNumber, ksefVerificationUrl));
+        return Task.FromResult(KSeFInvoicePdf.FromXml(xmlContent, colorScheme, ksefReferenceNumber, ksefVerificationUrl, ksefInvoiceHash));
     }
 
     public static void AssertPdfGeneratorAvailable()


### PR DESCRIPTION
Introduces a direct browser download option for the monthly CSV summary ("Pobierz CSV"), allowing users to download the file without saving it to the server. The existing "Podsumowanie CSV" button is renamed to "Zapisz CSV" to clarify the distinction between the two actions.

**Additional improvements:**
- Summary buttons ("Zapisz CSV" / "Pobierz CSV") are now enabled only when the invoice list is non-empty and are no longer blocked by busy state during other download operations
- NBP rate fetching now starts before the currency filter renders, so the UI correctly shows a loading indicator ("⏳ Pobieranie kursów NBP…") instead of a static waiting message
- Switching profiles fully clears the invoice view and refreshes token status synchronously, preventing stale cached invoices from appearing in the new profile context
- CSV generation logic is refactored into shared helpers to support both save-to-disk and browser download flows

**Dependency update:**
- KSeF client updated to v2.4.0, adding Problem Details error handling for 400/429/410 responses, HTTP 410 Gone support for expired export operations, and an `onlyMetadata` parameter for invoice exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser CSV download for monthly invoice summaries (new download control and separate Save/Download actions).
  * PDF enhancements: FA(3) annotation fields, margin-procedure details, and visible KSeF document hash in PDF header.
  * NBP rate loading indicator in the UI.

* **Bug Fixes**
  * Invoice list clears correctly on profile switch.
  * CSV controls enabled only when invoices exist.
  * VAT exemption labels and PDF annotation mappings corrected.

* **Chores**
  * KSeF client updated to v2.4.0 with improved error reporting and metadata export option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->